### PR TITLE
Ollama 로컬 LLM 연결 모드 추가 (#3)

### DIFF
--- a/sicode/main.py
+++ b/sicode/main.py
@@ -6,22 +6,91 @@
 
 from __future__ import annotations
 
+import argparse
 import builtins
+import os
 import sys
-from typing import Optional, Sequence
+from typing import Callable, Optional, Sequence
 
 from sicode.modes.base import BaseMode
+from sicode.modes.ollama import (
+    DEFAULT_HOST,
+    DEFAULT_MODEL,
+    OllamaClient,
+    OllamaMode,
+)
 from sicode.modes.simple import SimpleMode
 from sicode.repl import run_repl
 
 
-def _select_mode(_argv: Sequence[str]) -> BaseMode:
+#: 환경 변수 이름들. 한 곳에 모아두어 테스트와 도큐먼트가 일관되게 참조한다.
+ENV_OLLAMA_HOST: str = "SICODE_OLLAMA_HOST"
+ENV_OLLAMA_MODEL: str = "SICODE_OLLAMA_MODEL"
+
+
+def _build_simple_mode(_args: argparse.Namespace) -> BaseMode:
+    """``--mode simple`` 용 팩토리. 인자를 무시하고 SimpleMode 를 생성한다."""
+    return SimpleMode()
+
+
+def _build_ollama_mode(args: argparse.Namespace) -> BaseMode:
+    """``--mode ollama`` 용 팩토리.
+
+    호스트 URL 은 보안상 환경 변수(:data:`ENV_OLLAMA_HOST`) 로만 변경 가능하며 CLI 에서
+    임의 URL 을 직접 지정할 수 없다. 모델 이름은 CLI > 환경 변수 > 기본값 순으로 적용된다.
+    """
+    host = os.environ.get(ENV_OLLAMA_HOST, DEFAULT_HOST)
+    model = args.model or os.environ.get(ENV_OLLAMA_MODEL, DEFAULT_MODEL)
+    client = OllamaClient(host=host, model=model)
+    return OllamaMode(client=client)
+
+
+#: 모드 이름 -> 모드 팩토리 매핑. 새 모드를 추가할 때 이 딕셔너리에 한 줄만 더하면 된다 (OCP).
+MODES: "dict[str, Callable[[argparse.Namespace], BaseMode]]" = {
+    "simple": _build_simple_mode,
+    "ollama": _build_ollama_mode,
+}
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """CLI argparse 파서를 만든다.
+
+    - ``--mode`` : 사용할 모드 이름. 기본값은 ``simple``.
+    - ``--model`` : Ollama 모드에서 사용할 모델 이름. ``SICODE_OLLAMA_MODEL`` 보다 우선.
+
+    호스트 URL 옵션은 의도적으로 노출하지 않는다(보안 제약: 환경 변수 전용).
+    """
+    parser = argparse.ArgumentParser(
+        prog="sicode",
+        description="Claude Code 스타일의 sicode 대화형 CLI.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=sorted(MODES.keys()),
+        default="simple",
+        help="실행할 모드 (기본값: simple).",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help=(
+            "Ollama 모드에서 사용할 모델 이름. "
+            f"미지정 시 환경 변수 {ENV_OLLAMA_MODEL} 또는 기본값을 사용."
+        ),
+    )
+    return parser
+
+
+def _select_mode(argv: Sequence[str]) -> BaseMode:
     """CLI 인자에 따라 모드를 선택한다.
 
-    현재는 심플 모드만 지원하지만, 향후 ``--mode llm`` 등의 옵션을 추가할 때
-    이 함수만 확장하면 된다 (OCP).
+    모드 등록 레지스트리(:data:`MODES`)를 통해 새 모드 추가 시 본 함수 자체는 변경하지
+    않아도 되도록 했다 (OCP).
     """
-    return SimpleMode()
+    parser = _build_arg_parser()
+    args = parser.parse_args(list(argv))
+    factory = MODES[args.mode]
+    return factory(args)
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:

--- a/sicode/modes/__init__.py
+++ b/sicode/modes/__init__.py
@@ -5,6 +5,7 @@
 """
 
 from sicode.modes.base import BaseMode
+from sicode.modes.ollama import OllamaClient, OllamaError, OllamaMode
 from sicode.modes.simple import SimpleMode
 
-__all__ = ["BaseMode", "SimpleMode"]
+__all__ = ["BaseMode", "OllamaClient", "OllamaError", "OllamaMode", "SimpleMode"]

--- a/sicode/modes/ollama.py
+++ b/sicode/modes/ollama.py
@@ -1,0 +1,233 @@
+"""Ollama 로컬 LLM 연동 모드.
+
+`Ollama <https://ollama.com>`_ 가 로컬에서 실행 중일 때, ``POST /api/generate``
+엔드포인트로 비스트리밍 요청을 보내 응답 텍스트를 그대로 사용자에게 돌려준다.
+
+설계 메모:
+    - HTTP 통신은 :class:`OllamaClient` 로 분리하고, :class:`OllamaMode` 는 클라이언트
+      추상에만 의존한다 (DIP). 테스트에서 mock 클라이언트를 주입할 수 있다.
+    - 외부 라이브러리 없이 표준 라이브러리 ``urllib.request`` 만 사용한다.
+    - 다양한 네트워크/HTTP 오류는 :class:`OllamaError` 로 정규화하여 모드 레이어가
+      사용자에게 일관된 메시지를 보여줄 수 있게 한다 (SRP — 클라이언트는 통신과
+      에러 매핑, 모드는 사용자 메시지 포맷팅을 담당).
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from typing import Callable, Optional, Protocol
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+from sicode.modes.base import BaseMode
+
+
+#: 기본 Ollama 호스트. ``SICODE_OLLAMA_HOST`` 로 덮어쓸 수 있다.
+DEFAULT_HOST: str = "http://localhost:11434"
+
+#: 기본 모델 이름. ``SICODE_OLLAMA_MODEL`` 또는 CLI ``--model`` 로 덮어쓸 수 있다.
+DEFAULT_MODEL: str = "llama3"
+
+#: 단일 요청에 대한 타임아웃(초).
+DEFAULT_TIMEOUT_SECONDS: float = 30.0
+
+#: ``/api/generate`` 엔드포인트 경로.
+GENERATE_PATH: str = "/api/generate"
+
+
+class OllamaError(Exception):
+    """Ollama 통신 중 발생한 사용자에게 보여줄 만한 오류.
+
+    네트워크/HTTP 예외를 :class:`OllamaMode` 가 한 곳에서 처리할 수 있도록 정규화한다.
+    """
+
+
+class OllamaClientProtocol(Protocol):
+    """Ollama HTTP 호출을 추상화한 프로토콜.
+
+    한 가지 일(프롬프트 -> 응답 텍스트)만 책임지는 작은 인터페이스로, 테스트에서 mock
+    교체가 단순하다 (ISP).
+    """
+
+    def __call__(self, prompt: str) -> str:  # pragma: no cover - 프로토콜 정의
+        ...
+
+
+#: ``urlopen`` 시그니처와 호환되는 최소 타입(테스트에서 주입 가능).
+UrlOpener = Callable[..., object]
+
+
+class OllamaClient:
+    """``POST /api/generate`` 를 호출하는 비스트리밍 HTTP 클라이언트.
+
+    한 인스턴스는 (host, model, timeout) 한 묶음을 표현한다. 호출할 때마다 새로운
+    프롬프트를 받아 응답 텍스트를 반환한다.
+    """
+
+    def __init__(
+        self,
+        host: str = DEFAULT_HOST,
+        model: str = DEFAULT_MODEL,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        *,
+        url_opener: Optional[UrlOpener] = None,
+    ) -> None:
+        """클라이언트를 초기화한다.
+
+        Args:
+            host: Ollama 서버 베이스 URL. 끝에 슬래시가 있어도 정규화한다.
+            model: 사용할 모델 이름.
+            timeout: 단일 요청 타임아웃(초).
+            url_opener: ``urllib.request.urlopen`` 호환 함수. 테스트에서 주입한다.
+                ``None`` 이면 표준 ``urlopen`` 을 사용한다 (DIP).
+        """
+        self._host = host.rstrip("/")
+        self._model = model
+        self._timeout = timeout
+        self._url_opener: UrlOpener = url_opener or urlrequest.urlopen
+
+    @property
+    def host(self) -> str:
+        """현재 설정된 호스트 URL."""
+        return self._host
+
+    @property
+    def model(self) -> str:
+        """현재 설정된 모델 이름."""
+        return self._model
+
+    @property
+    def timeout(self) -> float:
+        """단일 요청 타임아웃(초)."""
+        return self._timeout
+
+    def __call__(self, prompt: str) -> str:
+        """프롬프트를 전송하고 응답 텍스트를 반환한다.
+
+        Args:
+            prompt: 모델에게 전달할 사용자 입력.
+
+        Returns:
+            모델이 생성한 텍스트(응답 JSON의 ``response`` 필드).
+
+        Raises:
+            OllamaError: 연결 거부, 타임아웃, HTTP 4xx/5xx 또는 응답 파싱 실패 시.
+        """
+        url = f"{self._host}{GENERATE_PATH}"
+        body = json.dumps(
+            {"model": self._model, "prompt": prompt, "stream": False}
+        ).encode("utf-8")
+        req = urlrequest.Request(
+            url,
+            data=body,
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+
+        try:
+            response = self._url_opener(req, timeout=self._timeout)
+        except urlerror.HTTPError as exc:  # 4xx/5xx (모델 미존재 포함)
+            detail = _safe_read(exc)
+            raise OllamaError(
+                f"Ollama HTTP {exc.code} error: {exc.reason}"
+                + (f" ({detail})" if detail else "")
+            ) from exc
+        except urlerror.URLError as exc:
+            reason = exc.reason
+            # ``URLError.reason`` 은 문자열일 수도, 다른 예외일 수도 있다.
+            if isinstance(reason, socket.timeout):
+                raise OllamaError(
+                    f"Ollama request timed out after {self._timeout:.0f}s"
+                ) from exc
+            if isinstance(reason, ConnectionRefusedError):
+                raise OllamaError(
+                    f"Ollama server refused connection at {self._host}"
+                ) from exc
+            raise OllamaError(
+                f"Ollama connection failed: {reason}"
+            ) from exc
+        except ConnectionRefusedError as exc:  # 직접 raw 소켓 거부
+            raise OllamaError(
+                f"Ollama server refused connection at {self._host}"
+            ) from exc
+        except socket.timeout as exc:  # urlopen 이 직접 timeout 을 던지는 경우
+            raise OllamaError(
+                f"Ollama request timed out after {self._timeout:.0f}s"
+            ) from exc
+
+        try:
+            with response:  # type: ignore[attr-defined]
+                raw = response.read()  # type: ignore[attr-defined]
+        except Exception as exc:  # pragma: no cover - 매우 드문 IO 실패
+            raise OllamaError(f"Failed to read Ollama response: {exc}") from exc
+
+        return _extract_response_text(raw)
+
+
+def _safe_read(exc: urlerror.HTTPError) -> str:
+    """HTTPError 의 본문을 가능한 만큼 안전하게 문자열로 변환한다."""
+    try:
+        data = exc.read()
+    except Exception:  # pragma: no cover - 본문이 이미 소진된 경우
+        return ""
+    if not data:
+        return ""
+    try:
+        return data.decode("utf-8", errors="replace").strip()
+    except Exception:  # pragma: no cover
+        return ""
+
+
+def _extract_response_text(raw: bytes) -> str:
+    """Ollama 응답 JSON에서 ``response`` 필드를 꺼낸다.
+
+    Raises:
+        OllamaError: JSON 파싱 실패 또는 ``response`` 필드 부재.
+    """
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise OllamaError(f"Invalid JSON from Ollama: {exc}") from exc
+
+    if not isinstance(payload, dict) or "response" not in payload:
+        raise OllamaError(
+            "Unexpected Ollama response shape: missing 'response' field"
+        )
+
+    response_text = payload["response"]
+    if not isinstance(response_text, str):
+        raise OllamaError(
+            "Unexpected Ollama response shape: 'response' is not a string"
+        )
+    return response_text
+
+
+class OllamaMode(BaseMode):
+    """Ollama 로컬 서버를 호출해 응답을 돌려주는 모드.
+
+    - REPL 코드는 :class:`BaseMode` 추상에만 의존하므로 본 모드 추가로 인한 REPL
+      변경은 없다 (OCP).
+    - HTTP 호출은 :class:`OllamaClientProtocol` 추상으로 위임한다 (DIP).
+    """
+
+    name = "ollama"
+
+    def __init__(self, client: OllamaClientProtocol) -> None:
+        """모드를 초기화한다.
+
+        Args:
+            client: 프롬프트를 받아 응답 텍스트를 반환하는 콜러블/객체.
+        """
+        self._client = client
+
+    def handle(self, user_input: str) -> str:
+        """사용자 입력을 Ollama 로 보내고 응답을 반환한다.
+
+        오류 시 REPL 을 종료시키지 않기 위해 :class:`OllamaError` 를 잡아 사용자에게
+        보여줄 메시지로 변환한다.
+        """
+        try:
+            return self._client(user_input)
+        except OllamaError as exc:
+            return f"[ollama] {exc}"

--- a/tests/modes/test_ollama.py
+++ b/tests/modes/test_ollama.py
@@ -1,0 +1,327 @@
+"""OllamaMode / OllamaClient 단위 테스트.
+
+실제 Ollama 서버 없이 동작하도록 ``urlopen`` 호환 콜러블을 mock 으로 주입한다.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import socket
+from typing import Any, Callable, List, Optional
+from urllib import error as urlerror
+
+import pytest
+
+from sicode.modes.base import BaseMode
+from sicode.modes.ollama import (
+    DEFAULT_HOST,
+    DEFAULT_MODEL,
+    DEFAULT_TIMEOUT_SECONDS,
+    GENERATE_PATH,
+    OllamaClient,
+    OllamaError,
+    OllamaMode,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _FakeHTTPResponse:
+    """`urlopen` 의 컨텍스트 매니저 호환 응답 객체."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._buf = io.BytesIO(payload)
+
+    def read(self) -> bytes:
+        return self._buf.read()
+
+    def __enter__(self) -> "_FakeHTTPResponse":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self._buf.close()
+
+
+def _make_opener(
+    payload: dict,
+    captured: Optional[List[dict]] = None,
+) -> Callable[..., _FakeHTTPResponse]:
+    """주어진 JSON 페이로드를 반환하는 가짜 ``urlopen`` 을 만든다.
+
+    호출 인자(요청 객체, timeout)는 ``captured`` 리스트에 기록된다.
+    """
+
+    def _opener(req: Any, timeout: float) -> _FakeHTTPResponse:
+        if captured is not None:
+            captured.append(
+                {
+                    "url": req.full_url,
+                    "method": req.get_method(),
+                    "headers": dict(req.header_items()),
+                    "body": req.data,
+                    "timeout": timeout,
+                }
+            )
+        return _FakeHTTPResponse(json.dumps(payload).encode("utf-8"))
+
+    return _opener
+
+
+def _raising_opener(exc: BaseException) -> Callable[..., Any]:
+    def _opener(_req: Any, timeout: float) -> Any:
+        raise exc
+
+    return _opener
+
+
+# ---------------------------------------------------------------------------
+# OllamaClient
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaClientHappyPath:
+    def test_returns_response_field_text(self) -> None:
+        opener = _make_opener({"response": "hi there", "done": True})
+        client = OllamaClient(url_opener=opener)
+        assert client("ping") == "hi there"
+
+    def test_request_url_method_headers_and_body(self) -> None:
+        captured: List[dict] = []
+        opener = _make_opener(
+            {"response": "ok"}, captured=captured
+        )
+        client = OllamaClient(
+            host="http://localhost:11434",
+            model="llama3",
+            url_opener=opener,
+        )
+        client("hello")
+
+        assert len(captured) == 1
+        rec = captured[0]
+        assert rec["url"] == f"http://localhost:11434{GENERATE_PATH}"
+        assert rec["method"] == "POST"
+        # urllib 은 헤더 키를 Title-Case 로 정규화한다.
+        assert rec["headers"].get("Content-type") == "application/json"
+        body = json.loads(rec["body"].decode("utf-8"))
+        assert body == {"model": "llama3", "prompt": "hello", "stream": False}
+
+    def test_default_timeout_is_passed_to_opener(self) -> None:
+        captured: List[dict] = []
+        opener = _make_opener({"response": "ok"}, captured=captured)
+        client = OllamaClient(url_opener=opener)
+        client("x")
+        assert captured[0]["timeout"] == DEFAULT_TIMEOUT_SECONDS
+
+    def test_custom_timeout_is_passed_to_opener(self) -> None:
+        captured: List[dict] = []
+        opener = _make_opener({"response": "ok"}, captured=captured)
+        client = OllamaClient(timeout=5.0, url_opener=opener)
+        client("x")
+        assert captured[0]["timeout"] == 5.0
+
+    def test_host_with_trailing_slash_is_normalized(self) -> None:
+        captured: List[dict] = []
+        opener = _make_opener({"response": "ok"}, captured=captured)
+        client = OllamaClient(
+            host="http://localhost:11434/", url_opener=opener
+        )
+        client("x")
+        assert captured[0]["url"] == f"http://localhost:11434{GENERATE_PATH}"
+
+    def test_host_and_model_properties(self) -> None:
+        client = OllamaClient(
+            host="http://example.com:9999",
+            model="mistral",
+            timeout=10.0,
+            url_opener=_make_opener({"response": "ok"}),
+        )
+        assert client.host == "http://example.com:9999"
+        assert client.model == "mistral"
+        assert client.timeout == 10.0
+
+
+class TestOllamaClientErrors:
+    def test_connection_refused_raises_ollama_error(self) -> None:
+        opener = _raising_opener(
+            urlerror.URLError(ConnectionRefusedError("refused"))
+        )
+        client = OllamaClient(url_opener=opener)
+        with pytest.raises(OllamaError) as exc_info:
+            client("hi")
+        assert "refused connection" in str(exc_info.value).lower()
+
+    def test_raw_connection_refused_raises_ollama_error(self) -> None:
+        opener = _raising_opener(ConnectionRefusedError("refused"))
+        client = OllamaClient(url_opener=opener)
+        with pytest.raises(OllamaError):
+            client("hi")
+
+    def test_timeout_via_urlerror_raises_ollama_error(self) -> None:
+        opener = _raising_opener(urlerror.URLError(socket.timeout()))
+        client = OllamaClient(url_opener=opener)
+        with pytest.raises(OllamaError) as exc_info:
+            client("hi")
+        assert "timed out" in str(exc_info.value).lower()
+
+    def test_raw_socket_timeout_raises_ollama_error(self) -> None:
+        opener = _raising_opener(socket.timeout())
+        client = OllamaClient(url_opener=opener)
+        with pytest.raises(OllamaError) as exc_info:
+            client("hi")
+        assert "timed out" in str(exc_info.value).lower()
+
+    def test_http_error_404_includes_status(self) -> None:
+        body = io.BytesIO(b'{"error":"model not found"}')
+        http_error = urlerror.HTTPError(
+            url="http://localhost:11434/api/generate",
+            code=404,
+            msg="Not Found",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=body,
+        )
+        opener = _raising_opener(http_error)
+        client = OllamaClient(url_opener=opener)
+        with pytest.raises(OllamaError) as exc_info:
+            client("hi")
+        assert "404" in str(exc_info.value)
+
+    def test_http_error_500(self) -> None:
+        http_error = urlerror.HTTPError(
+            url="http://localhost:11434/api/generate",
+            code=500,
+            msg="Internal Server Error",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=io.BytesIO(b""),
+        )
+        opener = _raising_opener(http_error)
+        client = OllamaClient(url_opener=opener)
+        with pytest.raises(OllamaError) as exc_info:
+            client("hi")
+        assert "500" in str(exc_info.value)
+
+    def test_invalid_json_raises_ollama_error(self) -> None:
+        def _opener(_req: Any, timeout: float) -> _FakeHTTPResponse:
+            return _FakeHTTPResponse(b"<<not json>>")
+
+        client = OllamaClient(url_opener=_opener)
+        with pytest.raises(OllamaError) as exc_info:
+            client("hi")
+        assert "json" in str(exc_info.value).lower()
+
+    def test_missing_response_field_raises_ollama_error(self) -> None:
+        def _opener(_req: Any, timeout: float) -> _FakeHTTPResponse:
+            return _FakeHTTPResponse(json.dumps({"foo": "bar"}).encode("utf-8"))
+
+        client = OllamaClient(url_opener=_opener)
+        with pytest.raises(OllamaError) as exc_info:
+            client("hi")
+        assert "response" in str(exc_info.value).lower()
+
+    def test_non_string_response_field_raises_ollama_error(self) -> None:
+        def _opener(_req: Any, timeout: float) -> _FakeHTTPResponse:
+            return _FakeHTTPResponse(json.dumps({"response": 123}).encode("utf-8"))
+
+        client = OllamaClient(url_opener=_opener)
+        with pytest.raises(OllamaError):
+            client("hi")
+
+    def test_generic_url_error_raises_ollama_error(self) -> None:
+        opener = _raising_opener(urlerror.URLError("dns failed"))
+        client = OllamaClient(url_opener=opener)
+        with pytest.raises(OllamaError) as exc_info:
+            client("hi")
+        assert "connection failed" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# OllamaMode
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaMode:
+    def test_is_a_basemode(self) -> None:
+        # LSP: BaseMode 자리에 그대로 대입 가능해야 한다.
+        mode = OllamaMode(client=lambda prompt: "x")
+        assert isinstance(mode, BaseMode)
+
+    def test_name_attribute(self) -> None:
+        assert OllamaMode(client=lambda p: "x").name == "ollama"
+
+    def test_handle_returns_client_response(self) -> None:
+        mode = OllamaMode(client=lambda prompt: f"echo:{prompt}")
+        assert mode.handle("hello") == "echo:hello"
+
+    def test_handle_passes_prompt_to_client(self) -> None:
+        seen: List[str] = []
+
+        def _client(prompt: str) -> str:
+            seen.append(prompt)
+            return "ok"
+
+        OllamaMode(client=_client).handle("hi there")
+        assert seen == ["hi there"]
+
+    def test_handle_returns_user_message_on_ollama_error(self) -> None:
+        def _client(prompt: str) -> str:
+            raise OllamaError("server is down")
+
+        out = OllamaMode(client=_client).handle("hello")
+        assert "[ollama]" in out
+        assert "server is down" in out
+
+    def test_handle_does_not_swallow_unexpected_exceptions(self) -> None:
+        # OllamaError 가 아닌 예외는 그대로 전파되어야 (REPL 의 종료 경로로 가지 않게)
+        # 한다. 이는 클라이언트 구현 버그를 숨기지 않기 위한 의도적 동작.
+        def _client(prompt: str) -> str:
+            raise RuntimeError("bug")
+
+        with pytest.raises(RuntimeError):
+            OllamaMode(client=_client).handle("hello")
+
+
+# ---------------------------------------------------------------------------
+# OllamaClient + OllamaMode 통합 (mock urlopen 까지 포함)
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaClientWithMode:
+    def test_end_to_end_with_mocked_urlopen(self) -> None:
+        opener = _make_opener({"response": "hello, world"})
+        client = OllamaClient(url_opener=opener)
+        mode = OllamaMode(client=client)
+        assert mode.handle("hi") == "hello, world"
+
+    def test_end_to_end_error_keeps_repl_alive(self) -> None:
+        # REPL 은 OllamaError 를 잡아 메시지로 변환한 응답을 받는다.
+        opener = _raising_opener(
+            urlerror.URLError(ConnectionRefusedError("refused"))
+        )
+        client = OllamaClient(url_opener=opener)
+        mode = OllamaMode(client=client)
+        result = mode.handle("hi")
+        assert result.startswith("[ollama]")
+        assert "refused" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# 모듈 상수 (회귀 방지)
+# ---------------------------------------------------------------------------
+
+
+class TestModuleConstants:
+    def test_default_host(self) -> None:
+        assert DEFAULT_HOST == "http://localhost:11434"
+
+    def test_default_model(self) -> None:
+        assert DEFAULT_MODEL == "llama3"
+
+    def test_default_timeout_is_30_seconds(self) -> None:
+        assert DEFAULT_TIMEOUT_SECONDS == 30.0
+
+    def test_generate_path(self) -> None:
+        assert GENERATE_PATH == "/api/generate"

--- a/tests/test_main_select_mode.py
+++ b/tests/test_main_select_mode.py
@@ -1,0 +1,115 @@
+"""``sicode.main._select_mode`` 의 모드 선택/우선순위 동작 테스트."""
+
+from __future__ import annotations
+
+import pytest
+
+import sicode.main as main_module
+from sicode.modes.ollama import (
+    DEFAULT_HOST,
+    DEFAULT_MODEL,
+    OllamaClient,
+    OllamaMode,
+)
+from sicode.modes.simple import SimpleMode
+
+
+class TestSelectModeDefault:
+    def test_no_args_returns_simple_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(main_module.ENV_OLLAMA_HOST, raising=False)
+        monkeypatch.delenv(main_module.ENV_OLLAMA_MODEL, raising=False)
+        assert isinstance(main_module._select_mode([]), SimpleMode)
+
+    def test_explicit_simple_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(main_module.ENV_OLLAMA_HOST, raising=False)
+        monkeypatch.delenv(main_module.ENV_OLLAMA_MODEL, raising=False)
+        assert isinstance(
+            main_module._select_mode(["--mode", "simple"]), SimpleMode
+        )
+
+
+class TestSelectModeOllama:
+    def test_ollama_mode_uses_defaults(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(main_module.ENV_OLLAMA_HOST, raising=False)
+        monkeypatch.delenv(main_module.ENV_OLLAMA_MODEL, raising=False)
+
+        mode = main_module._select_mode(["--mode", "ollama"])
+        assert isinstance(mode, OllamaMode)
+        client = mode._client  # type: ignore[attr-defined]
+        assert isinstance(client, OllamaClient)
+        assert client.host == DEFAULT_HOST
+        assert client.model == DEFAULT_MODEL
+
+    def test_env_var_overrides_default_host(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(main_module.ENV_OLLAMA_HOST, "http://example:9999")
+        monkeypatch.delenv(main_module.ENV_OLLAMA_MODEL, raising=False)
+
+        mode = main_module._select_mode(["--mode", "ollama"])
+        client = mode._client  # type: ignore[attr-defined]
+        assert isinstance(client, OllamaClient)
+        assert client.host == "http://example:9999"
+        assert client.model == DEFAULT_MODEL
+
+    def test_env_var_overrides_default_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(main_module.ENV_OLLAMA_HOST, raising=False)
+        monkeypatch.setenv(main_module.ENV_OLLAMA_MODEL, "mistral")
+
+        mode = main_module._select_mode(["--mode", "ollama"])
+        client = mode._client  # type: ignore[attr-defined]
+        assert client.model == "mistral"
+
+    def test_cli_model_overrides_env_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(main_module.ENV_OLLAMA_MODEL, "mistral")
+
+        mode = main_module._select_mode(
+            ["--mode", "ollama", "--model", "llama3"]
+        )
+        client = mode._client  # type: ignore[attr-defined]
+        assert client.model == "llama3"
+
+    def test_cli_model_overrides_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(main_module.ENV_OLLAMA_MODEL, raising=False)
+
+        mode = main_module._select_mode(
+            ["--mode", "ollama", "--model", "phi3"]
+        )
+        client = mode._client  # type: ignore[attr-defined]
+        assert client.model == "phi3"
+
+    def test_cli_does_not_accept_host_flag(self) -> None:
+        # 보안 제약: 호스트 URL 은 환경 변수로만 지정 가능. CLI ``--host`` 등의
+        # 옵션은 존재하지 않아야 한다 (argparse 가 SystemExit 으로 거부).
+        with pytest.raises(SystemExit):
+            main_module._select_mode(
+                ["--mode", "ollama", "--host", "http://attacker"]
+            )
+
+
+class TestSelectModeUnknown:
+    def test_unknown_mode_exits_via_argparse(self) -> None:
+        with pytest.raises(SystemExit):
+            main_module._select_mode(["--mode", "does-not-exist"])
+
+
+class TestModeRegistry:
+    def test_registry_contains_known_modes(self) -> None:
+        assert "simple" in main_module.MODES
+        assert "ollama" in main_module.MODES
+
+    def test_registry_factories_are_callable(self) -> None:
+        for factory in main_module.MODES.values():
+            assert callable(factory)


### PR DESCRIPTION
Closes #3

## 변경 요약 (개발자 에이전트 작성)

선행 PR #2의 OCP 구조(`BaseMode` 추상 + `_select_mode`) 위에 Ollama 로컬 LLM 모드를 새 모드로 추가했다. HTTP 통신은 표준 라이브러리 `urllib.request` 만으로 처리하고 `OllamaClient`(통신 + 에러 정규화) / `OllamaMode`(BaseMode 어댑터, 사용자 메시지 포맷팅)로 책임을 분리해 SRP·DIP를 만족시켰으며, `main.py`의 `_select_mode`는 모드 등록 레지스트리(`MODES`) + `argparse` 로 확장해 새 모드 추가 시 분기 코드를 더 쓸 필요가 없도록 정리했다 (OCP). 호스트 URL은 `SICODE_OLLAMA_HOST` 환경 변수로만 변경 가능하고 CLI에는 노출하지 않으며, 모델은 CLI `--model` > `SICODE_OLLAMA_MODEL` > 기본값 `llama3` 순으로 적용된다. 연결 거부 / 타임아웃 / 4xx·5xx HTTP 에러는 `OllamaError` 로 정규화되어 REPL을 종료시키지 않고 `[ollama] ...` 메시지만 출력한다.

## 변경된 파일
- `sicode/main.py`: `argparse` 도입, `MODES` 레지스트리(simple/ollama 팩토리) 추가, 환경 변수 상수(`ENV_OLLAMA_HOST`, `ENV_OLLAMA_MODEL`) 노출. CLI 인자 → 환경 변수 → 기본값 우선순위로 `OllamaMode` 조립. `--host` 옵션은 의도적으로 미노출(보안 제약).
- `sicode/modes/__init__.py`: 새 심볼(`OllamaMode`, `OllamaClient`, `OllamaError`) export.

## 추가된 파일
- `sicode/modes/ollama.py`: `OllamaClient`(POST `/api/generate` 비스트리밍, `urllib.request.urlopen` 의존성 주입, 30s 타임아웃), `OllamaClientProtocol`(테스트 더블용), `OllamaError`, `OllamaMode`(`BaseMode` 구현, `OllamaError → [ollama] ...` 메시지 변환).
- `tests/modes/__init__.py`: 빈 패키지 마커.
- `tests/modes/test_ollama.py` (28 케이스): 행복 경로(URL/메서드/헤더/바디/타임아웃/host 정규화), 에러 경로(연결 거부, 타임아웃, HTTP 404/500, 잘못된 JSON, 응답 필드 누락/비문자열), `OllamaMode` LSP/응답 위임/에러 메시지/비-OllamaError 전파, 통합 end-to-end mock.
- `tests/test_main_select_mode.py` (11 케이스): 기본 SimpleMode, `--mode simple`, `--mode ollama` 기본/env-only host/env-only model, **CLI `--model` > 환경 변수 우선순위**, 미상 모드 → SystemExit, **CLI `--host` 거부(보안 제약)**, 레지스트리 구조 검증.

## 테스트 결과
```
72 passed in 0.06s
```
기존 33개 회귀 없음 + 신규 39개 통과. 실제 로컬 Ollama 서버 수동 스모크: 모델 미존재 시 `[ollama] Ollama HTTP 404 error: Not Found ({"error":"model 'llama3' not found"})` 출력 후 REPL 유지 확인.

## PR #2 리뷰 Suggestion 반영
- ✅ 모드 등록 레지스트리 (`MODES`) 도입 (Suggestion 1)
- ⏸ `lambda prompt: builtins.input(prompt)` 단순화는 monkeypatch 호환성 유지를 위해 의도적으로 미적용 (기존 주석에 명시)

## 보안 고려
- CLI에 `--host` 미노출 (SSRF 우려). 호스트 변경은 `SICODE_OLLAMA_HOST` 환경 변수 전용.
- 외부 의존성 추가 0개 (표준 라이브러리만).
