### PR TITLE
슬래시 명령 시스템 도입 (/exit, /quit, /help) 및 확장 가능한 명령 레지스트리 구현 (#7)

### DIFF
--- a/sicode/commands/__init__.py
+++ b/sicode/commands/__init__.py
@@ -1,0 +1,54 @@
+"""슬래시 명령(`/exit`, `/help` 등) 패키지.
+
+REPL 루프에 명령 추가를 위한 분기 코드를 직접 작성하지 않고
+:class:`SlashCommand` 추상을 구현한 뒤 :func:`registry.register` 로
+명시적으로 등록만 하면 동작하는 구조를 제공한다 (OCP, DIP).
+
+사용 예::
+
+    from sicode.commands import register_default_commands
+
+    register_default_commands()
+"""
+
+from __future__ import annotations
+
+from sicode.commands.base import CommandResult, ReplContext, SlashCommand
+from sicode.commands.exit import ExitCommand
+from sicode.commands.help import HelpCommand
+from sicode.commands.registry import (
+    SlashCommandRegistry,
+    default_registry,
+    dispatch_command,
+    register,
+    reset,
+)
+
+
+def register_default_commands(registry: SlashCommandRegistry | None = None) -> None:
+    """기본 슬래시 명령(``/exit``, ``/quit``, ``/help``) 을 등록한다.
+
+    임포트 부수효과로 자동 등록하지 않으며, 본 함수의 명시적 호출이 등록 시점이다.
+
+    Args:
+        registry: 등록 대상 레지스트리. ``None`` 이면 모듈 전역
+            :data:`default_registry` 에 등록한다.
+    """
+    target = registry or default_registry
+    target.register(ExitCommand())
+    target.register(HelpCommand(registry=target))
+
+
+__all__ = [
+    "CommandResult",
+    "ExitCommand",
+    "HelpCommand",
+    "ReplContext",
+    "SlashCommand",
+    "SlashCommandRegistry",
+    "default_registry",
+    "dispatch_command",
+    "register",
+    "register_default_commands",
+    "reset",
+]

--- a/sicode/commands/base.py
+++ b/sicode/commands/base.py
@@ -1,0 +1,100 @@
+"""슬래시 명령 추상 인터페이스 및 결과 타입.
+
+설계 원칙:
+    - REPL 루프와 명령 구현은 :class:`SlashCommand` 추상에만 의존한다 (DIP).
+    - 작은 인터페이스(``name``/``aliases``/``description``/``execute``) 만 강제해
+      에코, 종료, 도움말 등 다양한 명령을 가볍게 추가할 수 있다 (ISP, SRP).
+    - 명령은 부작용으로 출력하지 않고, 출력 문자열을 반환값으로만 전달한다.
+      이렇게 분리하면 테스트 시 ``output_fn`` 캡처만으로 검증할 수 있다 (SRP).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - 타입 힌트 전용 임포트(런타임 순환 참조 회피)
+    from sicode.commands.registry import SlashCommandRegistry
+
+
+class CommandAction(Enum):
+    """명령 실행 후 REPL이 취해야 할 동작."""
+
+    #: REPL 루프를 계속 진행한다.
+    CONTINUE = "continue"
+    #: REPL 루프를 종료한다.
+    EXIT = "exit"
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """슬래시 명령 실행 결과.
+
+    Attributes:
+        action: 다음 REPL 동작(:class:`CommandAction`).
+        output: 출력할 문자열. 빈 문자열이면 출력하지 않는다.
+    """
+
+    action: CommandAction
+    output: str = ""
+
+    @classmethod
+    def cont(cls, output: str = "") -> "CommandResult":
+        """``CONTINUE`` 결과를 만든다 (가독성 헬퍼)."""
+        return cls(action=CommandAction.CONTINUE, output=output)
+
+    @classmethod
+    def exit_(cls, output: str = "") -> "CommandResult":
+        """``EXIT`` 결과를 만든다 (가독성 헬퍼). ``exit`` 가 키워드라 ``exit_``)."""
+        return cls(action=CommandAction.EXIT, output=output)
+
+
+@dataclass(frozen=True)
+class ReplContext:
+    """슬래시 명령에 노출되는 REPL 컨텍스트.
+
+    명령이 필요로 하는 최소 정보만 노출해 결합도를 낮춘다 (ISP).
+    현재는 ``/help`` 가 등록 명령 목록을 조회하는 용도로만 사용한다.
+
+    Attributes:
+        registry: 슬래시 명령 레지스트리. ``None`` 이면 명령은 레지스트리 정보를
+            사용하지 않는다고 가정한다.
+    """
+
+    registry: Optional["SlashCommandRegistry"] = None
+
+
+class SlashCommand(ABC):
+    """모든 슬래시 명령이 구현해야 하는 추상 인터페이스.
+
+    Attributes:
+        name: 슬래시 없이 비교되는 기본 이름(예: ``"exit"``).
+        aliases: 동일 동작에 매핑되는 별칭 목록(예: ``["quit"]``).
+        description: ``/help`` 출력에 사용되는 한 줄 설명.
+    """
+
+    name: str = ""
+    aliases: "tuple[str, ...]" = ()
+    description: str = ""
+
+    @abstractmethod
+    def execute(self, context: ReplContext) -> CommandResult:
+        """명령을 실행하고 :class:`CommandResult` 를 반환한다.
+
+        Args:
+            context: REPL 컨텍스트. 명령은 필요한 정보만 사용한다.
+
+        Returns:
+            REPL 의 후속 동작과 출력 문자열.
+        """
+        raise NotImplementedError
+
+
+__all__ = [
+    "CommandAction",
+    "CommandResult",
+    "ReplContext",
+    "SlashCommand",
+]

--- a/sicode/commands/exit.py
+++ b/sicode/commands/exit.py
@@ -1,0 +1,26 @@
+"""``/exit`` 및 ``/quit`` 슬래시 명령.
+
+REPL 루프 종료를 요청한다. 별칭 처리는 레지스트리가 ``aliases`` 에 따라
+이름과 동일한 명령으로 매핑한다.
+"""
+
+from __future__ import annotations
+
+from sicode.commands.base import CommandResult, ReplContext, SlashCommand
+
+
+class ExitCommand(SlashCommand):
+    """REPL 종료 명령.
+
+    출력은 평문 ``exit``/``quit`` 와 동일한 ``"Goodbye!"`` 로 통일한다.
+    """
+
+    name: str = "exit"
+    aliases: "tuple[str, ...]" = ("quit",)
+    description: str = "Exit the REPL."
+
+    def execute(self, context: ReplContext) -> CommandResult:  # noqa: ARG002 - 컨텍스트 미사용
+        return CommandResult.exit_(output="Goodbye!")
+
+
+__all__ = ["ExitCommand"]

--- a/sicode/commands/help.py
+++ b/sicode/commands/help.py
@@ -1,0 +1,50 @@
+"""``/help`` 슬래시 명령.
+
+등록된 모든 슬래시 명령(이름·별칭·설명)을 이름 알파벳 오름차순으로 출력한다.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from sicode.commands.base import CommandResult, ReplContext, SlashCommand
+
+if TYPE_CHECKING:  # pragma: no cover - 타입 힌트 전용
+    from sicode.commands.registry import SlashCommandRegistry
+
+
+class HelpCommand(SlashCommand):
+    """등록된 명령 목록을 출력한다.
+
+    레지스트리는 생성자 주입 또는 :class:`ReplContext` 로 전달받는다 (DIP).
+    생성자 주입이 우선되며, 둘 다 없으면 안내만 출력한다.
+    """
+
+    name: str = "help"
+    aliases: "tuple[str, ...]" = ()
+    description: str = "List all available slash commands."
+
+    def __init__(self, registry: Optional["SlashCommandRegistry"] = None) -> None:
+        self._registry = registry
+
+    def execute(self, context: ReplContext) -> CommandResult:
+        registry = self._registry or context.registry
+        if registry is None:
+            return CommandResult.cont(output="No commands registered.")
+
+        commands = registry.commands()
+        if not commands:
+            return CommandResult.cont(output="No commands registered.")
+
+        lines = ["Available commands:"]
+        for cmd in commands:
+            alias_text = (
+                f" (aliases: {', '.join('/' + a for a in cmd.aliases)})"
+                if cmd.aliases
+                else ""
+            )
+            lines.append(f"  /{cmd.name}{alias_text} - {cmd.description}")
+        return CommandResult.cont(output="\n".join(lines))
+
+
+__all__ = ["HelpCommand"]

--- a/sicode/commands/registry.py
+++ b/sicode/commands/registry.py
@@ -1,0 +1,212 @@
+"""슬래시 명령 레지스트리 및 디스패처.
+
+요구사항(이슈 #7):
+    - 모듈 수준 ``dict`` 기반 레지스트리.
+    - 등록은 명시적 :func:`register` 호출만 허용 (임포트 부수효과 자동 등록 금지).
+    - 미등록 명령은 ``"Unknown command: /foo. Type /help for available commands."`` 안내.
+    - 테스트 격리용 :func:`reset` 또는 컨텍스트 매니저 제공.
+
+SOLID 메모:
+    - SRP: 레지스트리는 등록/조회/디스패치만 담당하고, 출력은 호출부(REPL) 가 담당한다.
+    - OCP: 새 명령 추가 시 본 모듈을 수정하지 않고 :func:`register` 만 호출한다.
+    - DIP: 디스패치는 :class:`SlashCommand` 추상에만 의존한다.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Dict, Iterator, List, Optional
+
+from sicode.commands.base import (
+    CommandAction,
+    CommandResult,
+    ReplContext,
+    SlashCommand,
+)
+
+
+class SlashCommandRegistry:
+    """이름/별칭 -> :class:`SlashCommand` 매핑을 관리하는 레지스트리.
+
+    같은 이름/별칭을 두 번 등록하면 :class:`ValueError` 를 발생시켜
+    실수로 인한 덮어쓰기를 방지한다.
+    """
+
+    def __init__(self) -> None:
+        # 이름/별칭 모두를 같은 dict 에 저장하되, ``_primary_names`` 로 정렬·표시용
+        # 기본 이름 집합을 별도로 관리한다 (SRP: 두 책임을 명확히 구분).
+        self._by_token: Dict[str, SlashCommand] = {}
+        self._primary_names: List[str] = []
+
+    def register(self, command: SlashCommand) -> None:
+        """명령을 등록한다.
+
+        Args:
+            command: 등록할 :class:`SlashCommand` 인스턴스.
+
+        Raises:
+            ValueError: ``name`` 또는 ``aliases`` 가 비어 있거나 중복 등록 시.
+        """
+        if not command.name:
+            raise ValueError("SlashCommand.name must be a non-empty string")
+        tokens = (command.name, *command.aliases)
+        for token in tokens:
+            if not token:
+                raise ValueError("SlashCommand alias entries must be non-empty")
+            if token in self._by_token:
+                raise ValueError(f"Slash command token already registered: /{token}")
+        for token in tokens:
+            self._by_token[token] = command
+        self._primary_names.append(command.name)
+
+    def unregister(self, name: str) -> None:
+        """이름으로 명령을 제거한다. (테스트/런타임 수정용 보조 API)
+
+        Args:
+            name: 등록된 기본 이름.
+
+        Raises:
+            KeyError: 등록되지 않은 이름이면.
+        """
+        command = self._by_token.get(name)
+        if command is None or command.name != name:
+            raise KeyError(name)
+        for token in (command.name, *command.aliases):
+            self._by_token.pop(token, None)
+        self._primary_names.remove(command.name)
+
+    def reset(self) -> None:
+        """레지스트리를 비운다 (테스트 격리 등에서 사용)."""
+        self._by_token.clear()
+        self._primary_names.clear()
+
+    def get(self, token: str) -> Optional[SlashCommand]:
+        """이름 또는 별칭으로 명령을 조회한다. 없으면 ``None``."""
+        return self._by_token.get(token)
+
+    def commands(self) -> List[SlashCommand]:
+        """등록된 명령을 ``name`` 기준 알파벳 오름차순으로 반환한다.
+
+        ``/help`` 출력 정렬에 사용된다.
+        """
+        unique: Dict[str, SlashCommand] = {}
+        for name in self._primary_names:
+            cmd = self._by_token.get(name)
+            if cmd is not None:
+                unique[name] = cmd
+        return [unique[k] for k in sorted(unique.keys())]
+
+    def __contains__(self, token: object) -> bool:  # pragma: no cover - 단순 위임
+        return isinstance(token, str) and token in self._by_token
+
+    def __len__(self) -> int:  # pragma: no cover - 단순 위임
+        return len(self._primary_names)
+
+
+#: 모듈 전역 기본 레지스트리. 테스트는 :func:`reset` 으로 격리한다.
+default_registry: SlashCommandRegistry = SlashCommandRegistry()
+
+
+def register(command: SlashCommand) -> None:
+    """:data:`default_registry` 에 명령을 등록하는 모듈 수준 헬퍼."""
+    default_registry.register(command)
+
+
+def reset() -> None:
+    """:data:`default_registry` 를 초기화하는 모듈 수준 헬퍼."""
+    default_registry.reset()
+
+
+@contextmanager
+def temporary_registry() -> Iterator[SlashCommandRegistry]:
+    """테스트에서 전역 레지스트리를 일시적으로 비운 뒤 복구한다.
+
+    사용 예::
+
+        with temporary_registry() as reg:
+            reg.register(MyCommand())
+            ...
+    """
+    snapshot_by_token = dict(default_registry._by_token)
+    snapshot_primary = list(default_registry._primary_names)
+    default_registry.reset()
+    try:
+        yield default_registry
+    finally:
+        default_registry._by_token = snapshot_by_token
+        default_registry._primary_names = snapshot_primary
+
+
+def parse_slash_input(line: str) -> Optional[str]:
+    """입력 문자열을 슬래시 명령 토큰으로 변환한다.
+
+    슬래시(``/``) 로 시작하지 않으면 ``None`` 을 반환한다. 토큰은 슬래시를 제거하고
+    앞뒤 공백을 제거한 후 소문자로 정규화한다. (인자 파싱은 범위 외이므로 첫
+    공백까지만 토큰으로 인정한다.)
+    """
+    stripped = line.strip()
+    if not stripped.startswith("/"):
+        return None
+    body = stripped[1:].strip()
+    if not body:
+        return ""
+    # 첫 공백 이전까지를 토큰으로 사용 (인자 파싱은 향후 작업).
+    token = body.split(maxsplit=1)[0]
+    return token.lower()
+
+
+def dispatch_command(
+    line: str,
+    *,
+    registry: Optional[SlashCommandRegistry] = None,
+    context: Optional[ReplContext] = None,
+) -> CommandResult:
+    """슬래시 입력을 디스패치한다.
+
+    호출 규약:
+        - 호출 전에 ``line`` 이 ``/`` 로 시작하는지 확인했다고 가정한다.
+        - 미등록 명령이거나 슬래시만 입력된 경우, 안내 문자열과 ``CONTINUE`` 를 반환한다.
+
+    Args:
+        line: 사용자 입력 한 줄.
+        registry: 사용할 레지스트리. ``None`` 이면 :data:`default_registry`.
+        context: 명령에 전달할 :class:`ReplContext`. ``None`` 이면 본 함수가
+            레지스트리만 채워 생성한다.
+
+    Returns:
+        :class:`CommandResult`.
+    """
+    reg = registry or default_registry
+    token = parse_slash_input(line)
+    if token is None:
+        # 호출자가 보장하지 않은 경우의 방어적 처리. 슬래시가 아니면
+        # 그대로 CONTINUE 를 반환하며 출력은 비운다.
+        return CommandResult(action=CommandAction.CONTINUE, output="")
+
+    if token == "":
+        # ``/`` 만 입력된 경우 - help 안내로 폴백한다.
+        return CommandResult(
+            action=CommandAction.CONTINUE,
+            output="Unknown command: /. Type /help for available commands.",
+        )
+
+    command = reg.get(token)
+    if command is None:
+        return CommandResult(
+            action=CommandAction.CONTINUE,
+            output=f"Unknown command: /{token}. Type /help for available commands.",
+        )
+
+    ctx = context or ReplContext(registry=reg)
+    return command.execute(ctx)
+
+
+__all__ = [
+    "SlashCommandRegistry",
+    "default_registry",
+    "dispatch_command",
+    "parse_slash_input",
+    "register",
+    "reset",
+    "temporary_registry",
+]

--- a/sicode/main.py
+++ b/sicode/main.py
@@ -12,6 +12,7 @@ import os
 import sys
 from typing import Callable, Optional, Sequence
 
+from sicode.commands import default_registry, register_default_commands
 from sicode.modes.base import BaseMode
 from sicode.modes.ollama import (
     DEFAULT_HOST,
@@ -102,6 +103,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         argv = sys.argv[1:]
 
     mode = _select_mode(argv)
+    # 슬래시 명령 기본 셋(``/exit``, ``/quit``, ``/help``)을 명시적으로 등록한다.
+    # 이미 등록된 상태(같은 프로세스에서 main 두 번 호출 등)이면 무시한다.
+    if not default_registry.commands():
+        register_default_commands()
     # ``builtins.input`` / ``builtins.print`` 를 호출 시점에 조회해서 전달한다.
     # 이렇게 해야 테스트에서 ``monkeypatch.setattr("builtins.input", ...)`` 같은
     # 패치가 정상적으로 적용된다.

--- a/sicode/repl.py
+++ b/sicode/repl.py
@@ -2,6 +2,10 @@
 
 REPL은 :class:`sicode.modes.base.BaseMode` 추상에만 의존하며, I/O 함수(``input_fn``,
 ``output_fn``)를 주입받을 수 있어 테스트가 용이하다 (DIP, 의존성 주입).
+
+슬래시 명령(``/exit``, ``/help`` 등) 처리는 :mod:`sicode.commands` 의 디스패처에
+위임한다. REPL 루프의 분기 로직은 명령 추가에 무관하게 고정되어 있어, 새 명령은
+:func:`sicode.commands.register` 호출만으로 동작한다 (OCP).
 """
 
 from __future__ import annotations
@@ -9,6 +13,12 @@ from __future__ import annotations
 from typing import Callable, Iterable, Optional
 
 from sicode import __version__
+from sicode.commands.base import CommandAction
+from sicode.commands.registry import (
+    SlashCommandRegistry,
+    default_registry,
+    dispatch_command,
+)
 from sicode.modes.base import BaseMode
 
 
@@ -33,12 +43,18 @@ def build_welcome_message(mode: BaseMode, version: str = __version__) -> str:
         f"sicode v{version} ({mode.name} mode)\n"
         "Ollama 서버가 실행 중이어야 합니다 (기본: http://localhost:11434).\n"
         "Type 'exit' or 'quit' to leave. Press Ctrl+C / Ctrl+D to abort.\n"
+        "Type /help to see available slash commands.\n"
     )
 
 
 def is_exit_command(user_input: str) -> bool:
-    """입력이 종료 명령어인지 판정한다 (앞뒤 공백 무시, 대소문자 무시)."""
+    """입력이 평문 종료 명령어인지 판정한다 (앞뒤 공백 무시, 대소문자 무시)."""
     return user_input.strip().lower() in EXIT_COMMANDS
+
+
+def is_slash_command(user_input: str) -> bool:
+    """입력이 슬래시 명령(``/`` 로 시작)인지 판정한다 (앞 공백 무시)."""
+    return user_input.lstrip().startswith("/")
 
 
 def run_repl(
@@ -47,11 +63,14 @@ def run_repl(
     prompt: str = DEFAULT_PROMPT,
     input_fn: Callable[[str], str] = input,
     output_fn: Callable[[str], None] = print,
+    registry: Optional[SlashCommandRegistry] = None,
 ) -> int:
     """REPL 루프를 실행한다.
 
     설계 메모:
         - 모드는 :class:`BaseMode` 추상으로 받아 구체 구현을 모른다 (DIP).
+        - 슬래시 명령은 :mod:`sicode.commands` 디스패처에 위임해, 새 명령 추가가
+          본 함수의 변경 없이 가능하도록 했다 (OCP).
         - ``input_fn`` / ``output_fn`` 을 주입 가능하게 해서 단위 테스트에서
           실제 표준 입출력을 사용하지 않고 검증할 수 있다.
 
@@ -60,11 +79,14 @@ def run_repl(
         prompt: 사용자에게 표시할 프롬프트.
         input_fn: 한 줄 입력을 받을 함수. 기본값은 내장 ``input``.
         output_fn: 한 줄 출력을 수행할 함수. 기본값은 내장 ``print``.
+        registry: 슬래시 명령 레지스트리. ``None`` 이면 모듈 전역
+            :data:`sicode.commands.default_registry` 를 사용한다.
 
     Returns:
         프로세스 종료 코드. 정상 종료는 0.
     """
     output_fn(build_welcome_message(mode))
+    active_registry = registry or default_registry
 
     while True:
         try:
@@ -79,6 +101,15 @@ def run_repl(
             output_fn("")
             output_fn("Interrupted. Goodbye!")
             return 0
+
+        # 슬래시 명령은 mode.handle 보다 우선 처리한다 (LLM 미전송).
+        if is_slash_command(user_input):
+            result = dispatch_command(user_input, registry=active_registry)
+            if result.output:
+                output_fn(result.output)
+            if result.action is CommandAction.EXIT:
+                return 0
+            continue
 
         if is_exit_command(user_input):
             output_fn("Goodbye!")
@@ -100,6 +131,7 @@ def run_repl_with_inputs(
     *,
     prompt: str = DEFAULT_PROMPT,
     output_fn: Optional[Callable[[str], None]] = None,
+    registry: Optional[SlashCommandRegistry] = None,
 ) -> list[str]:
     """테스트 편의 함수: 주어진 입력 시퀀스로 REPL을 한 번 실행한다.
 
@@ -111,6 +143,7 @@ def run_repl_with_inputs(
         inputs: 한 줄씩 공급할 입력 시퀀스.
         prompt: 프롬프트(테스트용으로 무시 가능).
         output_fn: 출력 함수. ``None`` 이면 결과를 리스트에 모은다.
+        registry: 슬래시 명령 레지스트리(테스트 격리용).
 
     Returns:
         ``output_fn`` 이 ``None`` 이었을 경우 출력된 라인들의 리스트.
@@ -127,5 +160,11 @@ def run_repl_with_inputs(
 
     actual_output = output_fn or (lambda line: captured.append(line))
 
-    run_repl(mode, prompt=prompt, input_fn=_input, output_fn=actual_output)
+    run_repl(
+        mode,
+        prompt=prompt,
+        input_fn=_input,
+        output_fn=actual_output,
+        registry=registry,
+    )
     return captured

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,29 @@
 REPL 및 CLI 테스트는 실제 Ollama 서버에 의존하지 않아야 하므로,
 :class:`BaseMode` 의 가벼운 인메모리 구현체(:class:`EchoMode`)를 여기에 정의해
 여러 테스트 모듈에서 재사용한다 (DIP, OCP).
+
+또한 슬래시 명령 전역 레지스트리(:data:`sicode.commands.default_registry`)가
+테스트 간 누수되지 않도록 ``autouse`` 픽스처로 매 테스트 전후에 초기화한다.
 """
 
 from __future__ import annotations
 
 from typing import List
 
+import pytest
+
+from sicode.commands.registry import default_registry
 from sicode.modes.base import BaseMode
+
+
+@pytest.fixture(autouse=True)
+def _isolate_slash_command_registry() -> "Iterator[None]":  # type: ignore[name-defined]
+    """전역 슬래시 명령 레지스트리를 매 테스트 전후로 초기화한다 (테스트 격리)."""
+    default_registry.reset()
+    try:
+        yield
+    finally:
+        default_registry.reset()
 
 
 class EchoMode(BaseMode):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,326 @@
+"""슬래시 명령 시스템 단위 테스트.
+
+검증 범위:
+    - :class:`SlashCommand` / :class:`CommandResult` 계약.
+    - :class:`SlashCommandRegistry` 등록·조회·중복방지·정렬·리셋.
+    - 디스패처(``dispatch_command``) 의 분기/미상 명령 처리.
+    - ``/exit``, ``/quit``, ``/help`` 기본 명령 동작.
+    - 새 명령 등록만으로 REPL 무수정 동작(확장성).
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from sicode.commands import (
+    CommandResult,
+    ExitCommand,
+    HelpCommand,
+    ReplContext,
+    SlashCommand,
+    SlashCommandRegistry,
+    default_registry,
+    dispatch_command,
+    register,
+    register_default_commands,
+    reset,
+)
+from sicode.commands.base import CommandAction
+from sicode.commands.registry import parse_slash_input, temporary_registry
+from sicode.repl import run_repl_with_inputs
+from tests.conftest import EchoMode
+
+
+# ---------------------------------------------------------------------------
+# CommandResult / Enum
+# ---------------------------------------------------------------------------
+class TestCommandResult:
+    def test_action_enum_has_continue_and_exit(self) -> None:
+        assert CommandAction.CONTINUE != CommandAction.EXIT
+        assert {a.name for a in CommandAction} == {"CONTINUE", "EXIT"}
+
+    def test_cont_and_exit_helpers(self) -> None:
+        cont = CommandResult.cont("ok")
+        ex = CommandResult.exit_("bye")
+        assert cont.action is CommandAction.CONTINUE and cont.output == "ok"
+        assert ex.action is CommandAction.EXIT and ex.output == "bye"
+
+    def test_default_output_is_empty_string(self) -> None:
+        assert CommandResult.cont().output == ""
+        assert CommandResult.exit_().output == ""
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+class _DummyCommand(SlashCommand):
+    """확장성 테스트용 더미 명령."""
+
+    name = "dummy"
+    aliases = ("dm",)
+    description = "Dummy test command."
+
+    def __init__(self) -> None:
+        self.calls: List[ReplContext] = []
+
+    def execute(self, context: ReplContext) -> CommandResult:
+        self.calls.append(context)
+        return CommandResult.cont("dummy ran")
+
+
+class TestSlashCommandRegistry:
+    def test_register_and_get_by_name_and_alias(self) -> None:
+        reg = SlashCommandRegistry()
+        cmd = ExitCommand()
+        reg.register(cmd)
+        assert reg.get("exit") is cmd
+        assert reg.get("quit") is cmd
+        assert reg.get("nope") is None
+
+    def test_duplicate_registration_raises(self) -> None:
+        reg = SlashCommandRegistry()
+        reg.register(ExitCommand())
+        with pytest.raises(ValueError):
+            reg.register(ExitCommand())  # 같은 name/aliases 재등록
+
+    def test_register_rejects_empty_name(self) -> None:
+        class _Empty(SlashCommand):
+            name = ""
+            description = "empty"
+
+            def execute(self, context: ReplContext) -> CommandResult:
+                return CommandResult.cont()
+
+        reg = SlashCommandRegistry()
+        with pytest.raises(ValueError):
+            reg.register(_Empty())
+
+    def test_commands_returns_alphabetical_order(self) -> None:
+        reg = SlashCommandRegistry()
+        reg.register(HelpCommand(registry=reg))
+        reg.register(ExitCommand())
+        reg.register(_DummyCommand())
+        names = [c.name for c in reg.commands()]
+        assert names == sorted(names)
+        assert names == ["dummy", "exit", "help"]
+
+    def test_reset_clears_all(self) -> None:
+        reg = SlashCommandRegistry()
+        reg.register(ExitCommand())
+        reg.reset()
+        assert reg.get("exit") is None
+        assert reg.commands() == []
+
+    def test_unregister_removes_aliases_too(self) -> None:
+        reg = SlashCommandRegistry()
+        reg.register(ExitCommand())
+        reg.unregister("exit")
+        assert reg.get("exit") is None
+        assert reg.get("quit") is None
+        with pytest.raises(KeyError):
+            reg.unregister("exit")
+
+    def test_module_level_register_uses_default_registry(self) -> None:
+        register(ExitCommand())
+        assert default_registry.get("exit") is not None
+        reset()
+        assert default_registry.get("exit") is None
+
+    def test_temporary_registry_restores_state(self) -> None:
+        register(ExitCommand())
+        with temporary_registry() as reg:
+            assert reg.get("exit") is None  # 비어있어야 한다
+            reg.register(_DummyCommand())
+            assert reg.get("dummy") is not None
+        # 복구 후 원상태
+        assert default_registry.get("exit") is not None
+        assert default_registry.get("dummy") is None
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+class TestParseSlashInput:
+    @pytest.mark.parametrize(
+        "line,expected",
+        [
+            ("/exit", "exit"),
+            ("  /Exit ", "exit"),
+            ("/HELP", "help"),
+            ("/foo bar", "foo"),
+            ("hello", None),
+            ("", None),
+            ("/", ""),
+        ],
+    )
+    def test_parses_correctly(self, line: str, expected) -> None:
+        assert parse_slash_input(line) == expected
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+class TestDispatchCommand:
+    def test_dispatches_registered_command(self) -> None:
+        reg = SlashCommandRegistry()
+        cmd = ExitCommand()
+        reg.register(cmd)
+        result = dispatch_command("/exit", registry=reg)
+        assert result.action is CommandAction.EXIT
+        assert result.output == "Goodbye!"
+
+    def test_dispatches_alias(self) -> None:
+        reg = SlashCommandRegistry()
+        reg.register(ExitCommand())
+        result = dispatch_command("/quit", registry=reg)
+        assert result.action is CommandAction.EXIT
+
+    def test_unknown_command_returns_helpful_message(self) -> None:
+        reg = SlashCommandRegistry()
+        result = dispatch_command("/foo", registry=reg)
+        assert result.action is CommandAction.CONTINUE
+        assert result.output == (
+            "Unknown command: /foo. Type /help for available commands."
+        )
+
+    def test_only_slash_returns_unknown(self) -> None:
+        reg = SlashCommandRegistry()
+        result = dispatch_command("/", registry=reg)
+        assert result.action is CommandAction.CONTINUE
+        assert "Type /help" in result.output
+
+    def test_passes_context_to_command(self) -> None:
+        reg = SlashCommandRegistry()
+        dummy = _DummyCommand()
+        reg.register(dummy)
+        result = dispatch_command("/dummy", registry=reg)
+        assert result.action is CommandAction.CONTINUE
+        assert dummy.calls and dummy.calls[0].registry is reg
+
+    def test_case_insensitive_token(self) -> None:
+        reg = SlashCommandRegistry()
+        reg.register(ExitCommand())
+        result = dispatch_command("/EXIT", registry=reg)
+        assert result.action is CommandAction.EXIT
+
+
+# ---------------------------------------------------------------------------
+# /help command
+# ---------------------------------------------------------------------------
+class TestHelpCommand:
+    def test_lists_commands_alphabetically(self) -> None:
+        reg = SlashCommandRegistry()
+        reg.register(HelpCommand(registry=reg))
+        reg.register(ExitCommand())
+        result = dispatch_command("/help", registry=reg)
+        assert result.action is CommandAction.CONTINUE
+        # 본문에 등록 명령들이 알파벳 오름차순으로 등장해야 한다.
+        idx_exit = result.output.index("/exit")
+        idx_help = result.output.index("/help")
+        assert idx_exit < idx_help
+
+    def test_includes_aliases_and_description(self) -> None:
+        reg = SlashCommandRegistry()
+        reg.register(ExitCommand())
+        reg.register(HelpCommand(registry=reg))
+        result = dispatch_command("/help", registry=reg)
+        assert "/quit" in result.output  # 별칭
+        assert "Exit the REPL." in result.output
+
+    def test_help_with_empty_registry_is_safe(self) -> None:
+        # 컨텍스트로 레지스트리를 넘기는 경로를 검증한다.
+        cmd = HelpCommand()
+        result = cmd.execute(ReplContext(registry=SlashCommandRegistry()))
+        assert result.action is CommandAction.CONTINUE
+        assert "No commands" in result.output
+
+
+# ---------------------------------------------------------------------------
+# REPL integration
+# ---------------------------------------------------------------------------
+class TestReplSlashIntegration:
+    def test_slash_exit_terminates_repl(self) -> None:
+        register_default_commands()
+        mode = EchoMode()
+        outputs = run_repl_with_inputs(mode, ["/exit"])
+        assert mode.calls == []  # mode.handle 미호출
+        assert any("Goodbye" in line for line in outputs)
+
+    def test_slash_quit_terminates_repl(self) -> None:
+        register_default_commands()
+        mode = EchoMode()
+        outputs = run_repl_with_inputs(mode, ["/quit"])
+        assert mode.calls == []
+        assert any("Goodbye" in line for line in outputs)
+
+    def test_slash_help_lists_commands_and_keeps_repl_alive(self) -> None:
+        register_default_commands()
+        mode = EchoMode()
+        outputs = run_repl_with_inputs(mode, ["/help", "hello"])
+        # /help 는 mode.handle 호출하지 않음
+        assert mode.calls == ["hello"]
+        # 출력 어딘가에 등록 명령이 모두 등장해야 함
+        joined = "\n".join(outputs)
+        assert "/exit" in joined
+        assert "/help" in joined
+        assert "/quit" in joined
+
+    def test_unknown_slash_command_shows_message_and_continues(self) -> None:
+        register_default_commands()
+        mode = EchoMode()
+        outputs = run_repl_with_inputs(mode, ["/foo", "still alive"])
+        assert mode.calls == ["still alive"]
+        joined = "\n".join(outputs)
+        assert "Unknown command: /foo" in joined
+        assert "still alive" in outputs
+
+    def test_plain_exit_still_works_no_regression(self) -> None:
+        register_default_commands()
+        mode = EchoMode()
+        outputs = run_repl_with_inputs(mode, ["exit"])
+        assert mode.calls == []
+        assert any("Goodbye" in line for line in outputs)
+
+    def test_plain_quit_still_works_no_regression(self) -> None:
+        register_default_commands()
+        mode = EchoMode()
+        outputs = run_repl_with_inputs(mode, ["QUIT"])
+        assert mode.calls == []
+        assert any("Goodbye" in line for line in outputs)
+
+    def test_welcome_message_mentions_help(self) -> None:
+        register_default_commands()
+        outputs = run_repl_with_inputs(EchoMode(), ["/exit"])
+        assert any("/help" in line for line in outputs)
+
+    def test_dummy_command_extension_without_repl_changes(self) -> None:
+        """확장성: 새 명령을 등록만 하면 REPL 코드 수정 없이 동작한다 (OCP)."""
+
+        class _Greet(SlashCommand):
+            name = "greet"
+            aliases = ()
+            description = "Greet the user."
+
+            def __init__(self) -> None:
+                self.executed = 0
+
+            def execute(self, context: ReplContext) -> CommandResult:
+                self.executed += 1
+                return CommandResult.cont("hello there")
+
+        cmd = _Greet()
+        register(cmd)
+        mode = EchoMode()
+        outputs = run_repl_with_inputs(mode, ["/greet", "/exit"])
+        assert cmd.executed == 1
+        assert mode.calls == []  # mode.handle 미호출
+        assert "hello there" in outputs
+
+    def test_slash_commands_do_not_invoke_mode_handle(self) -> None:
+        """/exit · /quit · /help 모두 mode.handle 을 호출하지 않아야 한다."""
+        register_default_commands()
+        mode = EchoMode()
+        run_repl_with_inputs(mode, ["/help", "/quit"])
+        assert mode.calls == []


### PR DESCRIPTION
Closes #7

## 변경 요약 (개발자 에이전트 작성)

`sicode/commands/` 패키지에 `SlashCommand` 추상, `CommandResult`/`CommandAction` 결과 타입, 모듈 수준 `SlashCommandRegistry`(중복 등록 방지·알파벳 정렬 조회·`reset()`/`temporary_registry()` 격리 API), `dispatch_command` 디스패처, `/exit`(별칭 `/quit`)·`/help` 기본 명령을 추가. REPL 루프는 입력이 `/`로 시작하면 디스패처에 위임하고 그 외 경로(평문 `exit`/`quit`, 빈 입력, `mode.handle()`)는 그대로 유지 — 새 슬래시 명령은 `register()` 호출만으로 동작한다(OCP). 환영 메시지에 `/help` 안내 한 줄 추가, `main.py`에서 기본 명령을 명시적으로 등록(임포트 부수효과 자동 등록 없음). 테스트 격리를 위해 `conftest.py`에 `autouse` 픽스처로 전역 레지스트리를 매 테스트 전후 초기화.

## 변경된 파일
- 수정: `sicode/repl.py` (슬래시 분기 + 환영 메시지 + `registry` 주입 옵션), `sicode/main.py` (`register_default_commands()` 호출), `tests/conftest.py` (레지스트리 격리 autouse 픽스처).
- 신규: `sicode/commands/__init__.py` (공개 API + `register_default_commands()`), `sicode/commands/base.py` (`SlashCommand` ABC, `CommandAction` Enum, `CommandResult` dataclass, `ReplContext` dataclass), `sicode/commands/registry.py` (`SlashCommandRegistry`, `default_registry`, `register/reset/temporary_registry`, `parse_slash_input`, `dispatch_command`), `sicode/commands/exit.py`, `sicode/commands/help.py`.
- 신규 테스트: `tests/test_commands.py` (36 케이스).

## 테스트 결과
```
107 passed in 0.07s
```
기존 71 테스트 회귀 없음, 신규 36 추가 = 107 통과.

## 핵심 설계 결정
- **명령 등록**: 명시적 `registry.register()`만 허용. 임포트 부수효과 기반 자동 등록 사용하지 않음.
- **확장성**: 신규 `SlashCommand` 구현 + `register()` 한 줄로 동작 — `run_repl` 코드 수정 불필요(테스트로 검증, 더미 `/greet` 명령).
- **격리**: 모듈 수준 전역 레지스트리이지만 `temporary_registry()` 컨텍스트 매니저 + `conftest.py` autouse 픽스처로 테스트 누수 방지.
- **호환성**: 평문 `exit`/`quit` 동작 회귀 없음. 슬래시 토큰은 대소문자 무시(`/EXIT == /exit`) — 평문 `exit`/`quit`과 일관.
- **에러 처리**: 미상 명령 `/foo`는 안내 메시지 + REPL 유지(종료 X). 중복 등록은 `ValueError`로 silent override 방지.

## 범위 외 처리 (의도적 미구현)
- 명령 인자 파싱(`/help exit`)은 범위 외. `parse_slash_input`이 첫 토큰만 추출하므로 인자 지원 추가 시 시그니처만 확장 가능.
- 평문 `exit`/`quit` 폐기, 모드별 명령, 히스토리·자동완성, 새 모드 추가 — 모두 명시적 범위 외.
