### PR TITLE
feat: add /init slash command for SICODE.md project snapshot (#9)

### DIFF
--- a/sicode/commands/__init__.py
+++ b/sicode/commands/__init__.py
@@ -37,8 +37,18 @@ def register_default_commands(registry: SlashCommandRegistry | None = None) -> N
     # ``or`` 폴백을 쓰면 ``__len__`` 이 0인 빈 레지스트리가 falsy 로 평가되어
     # 의도와 달리 ``default_registry`` 로 가버린다. 명시적 ``is None`` 검사로 회피.
     target = default_registry if registry is None else registry
-    # ``InitCommand`` 는 ``sicode.commands.base`` 에 의존하므로, 본 패키지 임포트
-    # 시점에 같이 임포트하면 순환 참조가 발생한다. 등록 시점에 지연 임포트한다.
+    # NOTE(리뷰 라운드 2 정정): ``sicode.init.command`` 는 ``sicode.commands.base``
+    # 만 직접 임포트하지만, ``from sicode.commands.base import ...`` 구문은 부모
+    # 패키지인 ``sicode.commands`` 의 ``__init__`` (= 본 모듈) 을 먼저 실행시킨다.
+    # 따라서 본 모듈 최상위에서 ``InitCommand`` 를 import 하면 — ``sicode.commands``
+    # 가 부분 초기화 상태일 때 ``sicode.init.command`` 가 다시 본 모듈을 부르는
+    # 형태로 — 실제로 ``ImportError: cannot import name 'InitCommand' from
+    # partially initialized module 'sicode.init.command'`` 가 발생한다.
+    # (재현: ``python -c "from sicode.init.command import InitCommand"``.)
+    # 따라서 등록 시점에 지연 임포트를 유지한다. 더 깨끗한 해결은 ``init.command``
+    # 의 base 의존을 ``sicode.commands.base`` 가 아닌 별도 경로(예: 인터페이스
+    # 모듈을 ``sicode/cmdbase.py`` 로 분리)로 옮기는 것이지만, 본 PR 범위를 벗어
+    # 나므로 후속 작업으로 둔다.
     from sicode.init.command import InitCommand
 
     target.register(ExitCommand())

--- a/sicode/commands/__init__.py
+++ b/sicode/commands/__init__.py
@@ -26,7 +26,7 @@ from sicode.commands.registry import (
 
 
 def register_default_commands(registry: SlashCommandRegistry | None = None) -> None:
-    """기본 슬래시 명령(``/exit``, ``/quit``, ``/help``) 을 등록한다.
+    """기본 슬래시 명령(``/exit``, ``/quit``, ``/help``, ``/init``) 을 등록한다.
 
     임포트 부수효과로 자동 등록하지 않으며, 본 함수의 명시적 호출이 등록 시점이다.
 
@@ -34,9 +34,16 @@ def register_default_commands(registry: SlashCommandRegistry | None = None) -> N
         registry: 등록 대상 레지스트리. ``None`` 이면 모듈 전역
             :data:`default_registry` 에 등록한다.
     """
-    target = registry or default_registry
+    # ``or`` 폴백을 쓰면 ``__len__`` 이 0인 빈 레지스트리가 falsy 로 평가되어
+    # 의도와 달리 ``default_registry`` 로 가버린다. 명시적 ``is None`` 검사로 회피.
+    target = default_registry if registry is None else registry
+    # ``InitCommand`` 는 ``sicode.commands.base`` 에 의존하므로, 본 패키지 임포트
+    # 시점에 같이 임포트하면 순환 참조가 발생한다. 등록 시점에 지연 임포트한다.
+    from sicode.init.command import InitCommand
+
     target.register(ExitCommand())
     target.register(HelpCommand(registry=target))
+    target.register(InitCommand())
 
 
 __all__ = [

--- a/sicode/commands/__init__.py
+++ b/sicode/commands/__init__.py
@@ -37,18 +37,13 @@ def register_default_commands(registry: SlashCommandRegistry | None = None) -> N
     # ``or`` 폴백을 쓰면 ``__len__`` 이 0인 빈 레지스트리가 falsy 로 평가되어
     # 의도와 달리 ``default_registry`` 로 가버린다. 명시적 ``is None`` 검사로 회피.
     target = default_registry if registry is None else registry
-    # NOTE(리뷰 라운드 2 정정): ``sicode.init.command`` 는 ``sicode.commands.base``
-    # 만 직접 임포트하지만, ``from sicode.commands.base import ...`` 구문은 부모
-    # 패키지인 ``sicode.commands`` 의 ``__init__`` (= 본 모듈) 을 먼저 실행시킨다.
-    # 따라서 본 모듈 최상위에서 ``InitCommand`` 를 import 하면 — ``sicode.commands``
-    # 가 부분 초기화 상태일 때 ``sicode.init.command`` 가 다시 본 모듈을 부르는
-    # 형태로 — 실제로 ``ImportError: cannot import name 'InitCommand' from
-    # partially initialized module 'sicode.init.command'`` 가 발생한다.
-    # (재현: ``python -c "from sicode.init.command import InitCommand"``.)
-    # 따라서 등록 시점에 지연 임포트를 유지한다. 더 깨끗한 해결은 ``init.command``
-    # 의 base 의존을 ``sicode.commands.base`` 가 아닌 별도 경로(예: 인터페이스
-    # 모듈을 ``sicode/cmdbase.py`` 로 분리)로 옮기는 것이지만, 본 PR 범위를 벗어
-    # 나므로 후속 작업으로 둔다.
+    # NOTE(리뷰 라운드 3 정정): 본 모듈은 가벼운 부수효과만을 갖도록 유지한다.
+    # ``InitCommand`` 가 끌고 오는 scanner / renderer / Ollama HTTP 클라이언트
+    # 의존 그래프가 ``import sicode.commands`` 시점에 깨어나지 않도록, 등록 시점
+    # 까지 임포트를 지연시킨다. (라운드 2 주석에서 "순환 import" 라 적었던 부분은
+    # 부정확했음 — 클린 인터프리터에서 ``from sicode.init.command import InitCommand``
+    # 는 정상 동작한다. 본 모듈 최상위로 옮겨도 import 자체는 깨지지 않으나,
+    # 부수효과 무게를 줄이는 스타일 선택으로서 지연 import 를 유지한다.)
     from sicode.init.command import InitCommand
 
     target.register(ExitCommand())

--- a/sicode/init/__init__.py
+++ b/sicode/init/__init__.py
@@ -1,0 +1,44 @@
+"""``/init`` 슬래시 명령 패키지.
+
+현재 작업 디렉토리(:func:`pathlib.Path.cwd`)를 정적 분석해
+``SICODE.md`` 마크다운 파일로 저장하는 기능을 제공한다.
+
+설계 메모:
+    - SRP: 디렉토리 스캔(:mod:`.scanner`), 마크다운 변환(:mod:`.renderer`),
+      슬래시 명령 처리/파일 저장(:mod:`.command`) 책임을 모듈로 분리한다.
+    - DIP: ``InitCommand`` 는 콜러블 인터페이스에 의존하며 scanner/renderer/
+      summarizer 를 모두 주입 가능하다.
+    - OCP: ``register_default_commands()`` 에 ``InitCommand()`` 한 줄을 더하는 것
+      외에 REPL 코드는 변경하지 않는다.
+"""
+
+from __future__ import annotations
+
+from sicode.init.command import InitCommand, write_snapshot_file
+from sicode.init.renderer import render_markdown
+from sicode.init.scanner import (
+    DEFAULT_IGNORE_PATTERNS,
+    DEFAULT_MAX_DEPTH,
+    DEFAULT_MAX_FILE_BYTES,
+    DEFAULT_METADATA_PATTERNS,
+    DirectoryEntry,
+    FileEntry,
+    MetadataFile,
+    ProjectSnapshot,
+    scan_project,
+)
+
+__all__ = [
+    "DEFAULT_IGNORE_PATTERNS",
+    "DEFAULT_MAX_DEPTH",
+    "DEFAULT_MAX_FILE_BYTES",
+    "DEFAULT_METADATA_PATTERNS",
+    "DirectoryEntry",
+    "FileEntry",
+    "InitCommand",
+    "MetadataFile",
+    "ProjectSnapshot",
+    "render_markdown",
+    "scan_project",
+    "write_snapshot_file",
+]

--- a/sicode/init/command.py
+++ b/sicode/init/command.py
@@ -71,12 +71,43 @@ def _is_symlink(path: Path) -> bool:
     """``Path.is_symlink`` 의 ``OSError`` 안전 래퍼.
 
     ``lstat`` 호출이 권한 등으로 실패한 경우 보수적으로 ``True`` (심볼릭 가능성)
-    로 간주해 호출자가 거부하도록 만든다.
+    로 간주해 호출자가 거부하도록 만든다. 정상 디렉토리에서도 권한 문제로
+    실패할 수 있으므로, 호출자는 거부 시 사용자에게 "권한 또는 lstat 실패"
+    가능성을 함께 안내해야 한다.
     """
     try:
         return path.is_symlink()
     except OSError:
         return True
+
+
+def _validate_output_path(
+    output_path: Path,
+    backup_path: Optional[Path],
+) -> None:
+    """``write_snapshot_file`` 의 보안 정책 검사.
+
+    ``output_path`` 자체 또는 백업 대상 경로가 심볼릭 링크면
+    :class:`UnsafeOutputPathError` 를 던진다. 정책을 함수로 분리해 향후
+    "디렉토리 경계 검사" 등 새 정책 추가 시 본 함수만 확장하면 되도록 한다(OCP).
+
+    호출자(``InitCommand``)는 ``Path.absolute()`` (resolve 가 아님)로 만든
+    경로를 넘겨야 한다. ``resolve()`` 는 심볼릭 링크를 따라가 본 검사를 무력화
+    하므로(라운드 3 회귀), 호출 측에서 보장해야 한다.
+    """
+    if _is_symlink(output_path):
+        raise UnsafeOutputPathError(
+            f"refusing to write through a symlink "
+            f"(or lstat denied): {output_path}"
+        )
+    # 백업 경로는 호출자가 "기존 파일이 존재할 때만" 결정한다. 존재할 때만
+    # 심볼릭 검사. ``os.path.lexists`` 로 명시적으로 묶어 의도를 가시화한다.
+    if backup_path is not None and os.path.lexists(str(backup_path)):
+        if _is_symlink(backup_path):
+            raise UnsafeOutputPathError(
+                f"refusing to overwrite backup symlink "
+                f"(or lstat denied): {backup_path}"
+            )
 
 
 def write_snapshot_file(
@@ -90,7 +121,7 @@ def write_snapshot_file(
     백업은 ``output_path`` 와 같은 디렉토리에서 같은 파일명에 ``backup_suffix`` 를
     덧붙인 경로로 생성된다(기존 백업이 있으면 덮어쓴다 — 단일 백업만 유지).
 
-    보안 정책:
+    보안 정책 (자세한 것은 :func:`_validate_output_path` 참조):
         ``output_path`` 또는 백업 대상 경로가 **심볼릭 링크**라면
         :class:`UnsafeOutputPathError` 를 던지고 어떤 쓰기도 수행하지 않는다.
         심볼릭 링크를 따라가면 ``/etc/passwd`` 같은 외부 파일이 백업으로
@@ -100,9 +131,20 @@ def write_snapshot_file(
         이후 :func:`os.open` 에 ``O_NOFOLLOW`` 플래그로 새 파일을 만들어 본문을
         쓰므로 출력 경로 작성 단계에서도 link follow 가 차단된다.
 
+    호출자 계약 (Critical):
+        호출자는 **반드시 ``Path.absolute()`` (또는 동등한 비-resolve 경로)** 를
+        넘겨야 한다. ``Path.resolve()`` / ``os.path.realpath`` 는 심볼릭 링크를
+        선제적으로 따라가므로 본 함수의 ``is_symlink`` 검사가 무력화된다
+        (라운드 3 회귀). ``InitCommand.execute`` 가 이 계약을 지킨다.
+
+    플랫폼:
+        ``O_NOFOLLOW`` 는 Linux/macOS 에서 leaf 심볼릭을 거부한다. 일부 NFS /
+        특수 파일시스템에서는 무시될 수 있어 단독 방어선으로 신뢰하지 말고,
+        반드시 위 ``_validate_output_path`` 의 사전 검사와 결합한다.
+
     Args:
         markdown: 저장할 본문.
-        output_path: 저장 경로(절대 권장).
+        output_path: 저장 경로(절대 권장, ``absolute()`` 결과 권장).
         backup_suffix: 백업 파일에 덧붙일 접미사. 기본값 ``".bak"``.
 
     Returns:
@@ -111,23 +153,15 @@ def write_snapshot_file(
     Raises:
         UnsafeOutputPathError: ``output_path`` 또는 백업 대상이 심볼릭 링크일 때.
     """
-    # 1) 출력 경로 자체가 심볼릭 링크면 거부. ``Path.exists()`` 는 링크가
-    #    가리키는 대상의 존재 여부이므로, 링크 검사는 ``is_symlink`` 가 정확.
-    if _is_symlink(output_path):
-        raise UnsafeOutputPathError(
-            f"refusing to write through a symlink: {output_path}"
-        )
-
+    # 1) 출력 경로 자체의 심볼릭 검사를 먼저 수행. 백업 경로는 출력이 이미 존재
+    #    할 때만 의미가 있으므로, ``lexists`` 분기 안에서 함께 검증한다.
     backup_path: Optional[Path] = None
-    # ``Path.exists()`` 는 링크 follow 후 결과지만 위에서 링크면 이미 거부했고,
-    # ``lexists`` 와 동등한 효과를 위해 ``os.path.lexists`` 를 사용한다.
     if os.path.lexists(str(output_path)):
         backup_path = output_path.with_name(output_path.name + backup_suffix)
-        # 백업 대상도 심볼릭 링크면 거부(외부 임의 파일을 덮어쓸 가능성).
-        if _is_symlink(backup_path):
-            raise UnsafeOutputPathError(
-                f"refusing to overwrite backup symlink: {backup_path}"
-            )
+
+    _validate_output_path(output_path, backup_path)
+
+    if backup_path is not None:
         # ``shutil.copy2`` 는 source 의 링크를 follow 하므로 사용하지 않는다.
         # ``os.replace`` 는 원본 파일을 (혹은 링크 자체를) 그대로 백업 경로로
         # 이동시키므로 데이터 유출 경로가 닫힌다. 또한 원자적이다.
@@ -216,7 +250,13 @@ class InitCommand(SlashCommand):
         self._output_filename = output_filename
 
     def execute(self, context: ReplContext) -> CommandResult:  # noqa: ARG002 - 컨텍스트 미사용
-        root = self._cwd_fn().resolve()
+        # 보안 주의(리뷰 라운드 3): ``Path.resolve()`` 는 심볼릭 링크를 따라가
+        # 타겟의 실제 경로를 반환한다. 그 결과 SICODE.md 자리에 외부 파일을
+        # 가리키는 심볼릭 링크가 있으면, writer 가 받은 경로는 외부 파일의
+        # 실제 경로가 되어 ``write_snapshot_file`` 의 ``is_symlink`` 검사가
+        # 무력화된다(타겟은 일반 파일이므로 통과). 따라서 cwd / output 모두
+        # ``Path.absolute()`` 로 심볼릭을 풀지 않은 절대 경로만 만든다.
+        root = self._cwd_fn().absolute()
         snapshot = self._scanner(root)
 
         llm_summary: Optional[str] = None
@@ -224,7 +264,7 @@ class InitCommand(SlashCommand):
             llm_summary = self._safely_summarize(snapshot)
 
         markdown = self._renderer(snapshot, llm_summary)
-        output_path = (root / self._output_filename).resolve()
+        output_path = (root / self._output_filename).absolute()
         result = self._writer(markdown, output_path)
 
         lines: list[str] = []

--- a/sicode/init/command.py
+++ b/sicode/init/command.py
@@ -1,0 +1,189 @@
+"""``/init`` 슬래시 명령 구현.
+
+요구사항(이슈 #9):
+    - ``/init`` 입력 시 :func:`Path.cwd` 를 루트로 정적 분석 결과를 모아 마크다운으로 저장.
+    - 결과 파일 기본 경로는 ``<cwd>/SICODE.md``. 이미 존재하면 ``SICODE.md.bak`` 로 백업.
+    - 백업이 발생하면 그 사실을 REPL 출력에 포함, 저장 후에는 절대 경로를 출력.
+    - Ollama 가 가용하면 자연어 요약을 추가하고, 실패하면 정적 분석 결과만으로 정상 완료.
+    - 인자는 받지 않는다.
+
+설계 메모:
+    - DIP: scanner / renderer / Ollama summarizer / file writer 를 모두 콜러블로 주입.
+      기본값은 모듈 수준 헬퍼이다. 테스트는 mock 으로 교체한다.
+    - SRP: 본 클래스는 "스캔 -> 렌더 -> 저장 -> 출력 문자열 조립" 의 흐름 제어만 담당.
+      파일 시스템 조작은 :func:`write_snapshot_file` 로 분리해 단위 테스트가 용이하다.
+    - OCP: 새 명령 추가 시 ``register_default_commands`` 한 줄만 변경된다.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional, Protocol
+
+from sicode.commands.base import CommandResult, ReplContext, SlashCommand
+from sicode.init.renderer import render_markdown
+from sicode.init.scanner import ProjectSnapshot, scan_project
+
+
+#: 결과 마크다운 기본 파일 이름.
+DEFAULT_OUTPUT_FILENAME: str = "SICODE.md"
+
+#: 백업 파일 이름(``SICODE.md`` 가 이미 존재할 때 사용).
+DEFAULT_BACKUP_SUFFIX: str = ".bak"
+
+
+class ProjectSummarizer(Protocol):
+    """:class:`ProjectSnapshot` -> 자연어 요약 텍스트 변환자.
+
+    Ollama 가 꺼져 있거나 오류가 발생할 수 있어 호출자는 반드시 예외를 핸들링한다.
+    예외는 어떤 종류든 상위에서 잡아 무시한다(요약 없이 정상 완료).
+    """
+
+    def __call__(self, snapshot: ProjectSnapshot) -> str:  # pragma: no cover - 프로토콜
+        ...
+
+
+@dataclass(frozen=True)
+class WriteResult:
+    """파일 저장 결과.
+
+    Attributes:
+        output_path: 저장된 마크다운 파일의 절대 경로.
+        backup_path: 백업이 만들어졌으면 그 절대 경로, 없으면 ``None``.
+    """
+
+    output_path: Path
+    backup_path: Optional[Path]
+
+
+def write_snapshot_file(
+    markdown: str,
+    output_path: Path,
+    *,
+    backup_suffix: str = DEFAULT_BACKUP_SUFFIX,
+) -> WriteResult:
+    """마크다운을 ``output_path`` 에 저장한다. 이미 파일이 있으면 백업한다.
+
+    백업은 ``output_path`` 와 같은 디렉토리에서 같은 파일명에 ``backup_suffix`` 를
+    덧붙인 경로로 생성된다(기존 백업이 있으면 덮어쓴다 — 단일 백업만 유지).
+
+    Args:
+        markdown: 저장할 본문.
+        output_path: 저장 경로(절대 권장).
+        backup_suffix: 백업 파일에 덧붙일 접미사. 기본값 ``".bak"``.
+
+    Returns:
+        :class:`WriteResult`.
+    """
+    backup_path: Optional[Path] = None
+    if output_path.exists():
+        backup_path = output_path.with_name(output_path.name + backup_suffix)
+        # 기존 백업이 있으면 덮어쓴다(단일 백업 유지). 디렉토리/심볼릭 등 예외적
+        # 케이스는 그대로 OSError 가 전파되도록 둔다 — 사용자에게 메시지로 노출 가능.
+        shutil.copy2(str(output_path), str(backup_path))
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(markdown, encoding="utf-8")
+    return WriteResult(output_path=output_path, backup_path=backup_path)
+
+
+#: 기본 scanner / renderer / writer 시그니처. 테스트에서는 mock 으로 교체된다.
+ScannerFn = Callable[[Path], ProjectSnapshot]
+RendererFn = Callable[[ProjectSnapshot, Optional[str]], str]
+WriterFn = Callable[[str, Path], WriteResult]
+CwdFn = Callable[[], Path]
+
+
+def _default_scanner(root: Path) -> ProjectSnapshot:
+    return scan_project(root)
+
+
+def _default_renderer(snapshot: ProjectSnapshot, llm_summary: Optional[str]) -> str:
+    return render_markdown(snapshot, llm_summary=llm_summary)
+
+
+def _default_writer(markdown: str, output_path: Path) -> WriteResult:
+    return write_snapshot_file(markdown, output_path)
+
+
+class InitCommand(SlashCommand):
+    """현재 디렉토리를 정적 분석해 ``SICODE.md`` 로 저장하는 슬래시 명령.
+
+    DI 가능한 협력자:
+        scanner: ``Path`` -> :class:`ProjectSnapshot`.
+        renderer: ``(snapshot, llm_summary)`` -> 마크다운 문자열.
+        writer: ``(markdown, output_path)`` -> :class:`WriteResult`.
+        summarizer: 선택적 자연어 요약기. 예외는 본 클래스가 잡아 무시한다.
+        cwd_fn: 작업 디렉토리 제공자(테스트에서 ``tmp_path`` 주입용).
+        output_filename: 결과 파일 이름. 기본 ``SICODE.md``.
+    """
+
+    name: str = "init"
+    aliases: "tuple[str, ...]" = ()
+    description: str = "Scan current directory and save context to SICODE.md."
+
+    def __init__(
+        self,
+        *,
+        scanner: ScannerFn = _default_scanner,
+        renderer: RendererFn = _default_renderer,
+        writer: WriterFn = _default_writer,
+        summarizer: Optional[ProjectSummarizer] = None,
+        cwd_fn: CwdFn = Path.cwd,
+        output_filename: str = DEFAULT_OUTPUT_FILENAME,
+    ) -> None:
+        self._scanner = scanner
+        self._renderer = renderer
+        self._writer = writer
+        self._summarizer = summarizer
+        self._cwd_fn = cwd_fn
+        self._output_filename = output_filename
+
+    def execute(self, context: ReplContext) -> CommandResult:  # noqa: ARG002 - 컨텍스트 미사용
+        root = self._cwd_fn().resolve()
+        snapshot = self._scanner(root)
+
+        llm_summary: Optional[str] = None
+        if self._summarizer is not None:
+            llm_summary = self._safely_summarize(snapshot)
+
+        markdown = self._renderer(snapshot, llm_summary)
+        output_path = (root / self._output_filename).resolve()
+        result = self._writer(markdown, output_path)
+
+        lines: list[str] = []
+        if result.backup_path is not None:
+            lines.append(f"Existing file backed up to: {result.backup_path}")
+        if llm_summary:
+            lines.append("Included LLM summary from Ollama.")
+        lines.append(f"Saved project snapshot to: {result.output_path}")
+        return CommandResult.cont("\n".join(lines))
+
+    # ------------------------------------------------------------------ helpers
+
+    def _safely_summarize(self, snapshot: ProjectSnapshot) -> Optional[str]:
+        """Summarizer 호출에서 발생하는 모든 예외를 흡수한다.
+
+        Ollama 서버가 꺼져 있어도 명령이 정상 완료되도록 광범위한 ``Exception`` 을
+        잡는다. 시스템 예외(``KeyboardInterrupt``, ``SystemExit``)는 전파한다.
+        """
+        try:
+            text = self._summarizer(snapshot)  # type: ignore[misc]
+        except Exception:
+            return None
+        if not isinstance(text, str):
+            return None
+        text = text.strip()
+        return text or None
+
+
+__all__ = [
+    "DEFAULT_BACKUP_SUFFIX",
+    "DEFAULT_OUTPUT_FILENAME",
+    "InitCommand",
+    "ProjectSummarizer",
+    "WriteResult",
+    "write_snapshot_file",
+]

--- a/sicode/init/command.py
+++ b/sicode/init/command.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-import shutil
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional, Protocol
@@ -45,6 +45,15 @@ class ProjectSummarizer(Protocol):
         ...
 
 
+class UnsafeOutputPathError(OSError):
+    """``write_snapshot_file`` 이 보안 정책상 거부한 출력 경로.
+
+    구체적으로 ``output_path`` 자체 또는 백업 대상 경로가 심볼릭 링크인 경우.
+    심볼릭 링크를 따라가면 ``shutil.copy2`` / ``Path.write_text`` 가 외부 임의
+    파일을 백업/덮어쓸 수 있어 보안 결함이 된다(데이터 유출/임의 파일 변조).
+    """
+
+
 @dataclass(frozen=True)
 class WriteResult:
     """파일 저장 결과.
@@ -58,6 +67,18 @@ class WriteResult:
     backup_path: Optional[Path]
 
 
+def _is_symlink(path: Path) -> bool:
+    """``Path.is_symlink`` 의 ``OSError`` 안전 래퍼.
+
+    ``lstat`` 호출이 권한 등으로 실패한 경우 보수적으로 ``True`` (심볼릭 가능성)
+    로 간주해 호출자가 거부하도록 만든다.
+    """
+    try:
+        return path.is_symlink()
+    except OSError:
+        return True
+
+
 def write_snapshot_file(
     markdown: str,
     output_path: Path,
@@ -69,6 +90,16 @@ def write_snapshot_file(
     백업은 ``output_path`` 와 같은 디렉토리에서 같은 파일명에 ``backup_suffix`` 를
     덧붙인 경로로 생성된다(기존 백업이 있으면 덮어쓴다 — 단일 백업만 유지).
 
+    보안 정책:
+        ``output_path`` 또는 백업 대상 경로가 **심볼릭 링크**라면
+        :class:`UnsafeOutputPathError` 를 던지고 어떤 쓰기도 수행하지 않는다.
+        심볼릭 링크를 따라가면 ``/etc/passwd`` 같은 외부 파일이 백업으로
+        복제되거나 덮어쓰일 수 있는 데이터 유출/임의 변조 경로가 열린다.
+        백업은 :func:`os.replace` 로 수행해 원본 파일(또는 링크 메타데이터)을
+        원자적으로 백업 경로로 이동하므로 link follow 가 발생하지 않는다.
+        이후 :func:`os.open` 에 ``O_NOFOLLOW`` 플래그로 새 파일을 만들어 본문을
+        쓰므로 출력 경로 작성 단계에서도 link follow 가 차단된다.
+
     Args:
         markdown: 저장할 본문.
         output_path: 저장 경로(절대 권장).
@@ -76,16 +107,59 @@ def write_snapshot_file(
 
     Returns:
         :class:`WriteResult`.
+
+    Raises:
+        UnsafeOutputPathError: ``output_path`` 또는 백업 대상이 심볼릭 링크일 때.
     """
+    # 1) 출력 경로 자체가 심볼릭 링크면 거부. ``Path.exists()`` 는 링크가
+    #    가리키는 대상의 존재 여부이므로, 링크 검사는 ``is_symlink`` 가 정확.
+    if _is_symlink(output_path):
+        raise UnsafeOutputPathError(
+            f"refusing to write through a symlink: {output_path}"
+        )
+
     backup_path: Optional[Path] = None
-    if output_path.exists():
+    # ``Path.exists()`` 는 링크 follow 후 결과지만 위에서 링크면 이미 거부했고,
+    # ``lexists`` 와 동등한 효과를 위해 ``os.path.lexists`` 를 사용한다.
+    if os.path.lexists(str(output_path)):
         backup_path = output_path.with_name(output_path.name + backup_suffix)
-        # 기존 백업이 있으면 덮어쓴다(단일 백업 유지). 디렉토리/심볼릭 등 예외적
-        # 케이스는 그대로 OSError 가 전파되도록 둔다 — 사용자에게 메시지로 노출 가능.
-        shutil.copy2(str(output_path), str(backup_path))
+        # 백업 대상도 심볼릭 링크면 거부(외부 임의 파일을 덮어쓸 가능성).
+        if _is_symlink(backup_path):
+            raise UnsafeOutputPathError(
+                f"refusing to overwrite backup symlink: {backup_path}"
+            )
+        # ``shutil.copy2`` 는 source 의 링크를 follow 하므로 사용하지 않는다.
+        # ``os.replace`` 는 원본 파일을 (혹은 링크 자체를) 그대로 백업 경로로
+        # 이동시키므로 데이터 유출 경로가 닫힌다. 또한 원자적이다.
+        os.replace(str(output_path), str(backup_path))
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(markdown, encoding="utf-8")
+    # ``Path.write_text`` 는 내부적으로 ``open`` 을 사용하며 결과적으로 링크를
+    # follow 한다. 위 검사에서 링크는 거부했지만 TOCTOU 회피를 위해 ``O_NOFOLLOW``
+    # 플래그를 명시한다. ``O_EXCL`` 까지 결합하면 백업 직후 race 로 새로 생긴
+    # 링크/파일도 만들지 못해 보다 안전하다.
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW
+    if hasattr(os, "O_EXCL") and backup_path is not None:
+        # 백업으로 옮겼으니 출력 경로는 비어 있어야 하며, 새로 만들어진다.
+        flags |= os.O_EXCL
+    try:
+        fd = os.open(str(output_path), flags, 0o644)
+    except OSError as exc:
+        # ``O_NOFOLLOW`` 가 링크를 만났을 때 ``ELOOP`` 또는 플랫폼 별 에러로
+        # 떨어진다. 사용자에게 보안 의도를 명확히 전달.
+        raise UnsafeOutputPathError(
+            f"refusing to write through a symlink (race or stale): {output_path}"
+        ) from exc
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(markdown)
+    except Exception:
+        # fdopen 실패 시 fd 누수 방지(정상 경로에서는 with 가 close).
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        raise
     return WriteResult(output_path=output_path, backup_path=backup_path)
 
 
@@ -184,6 +258,7 @@ __all__ = [
     "DEFAULT_OUTPUT_FILENAME",
     "InitCommand",
     "ProjectSummarizer",
+    "UnsafeOutputPathError",
     "WriteResult",
     "write_snapshot_file",
 ]

--- a/sicode/init/renderer.py
+++ b/sicode/init/renderer.py
@@ -1,0 +1,213 @@
+r"""``ProjectSnapshot`` -> 마크다운 문자열 변환기.
+
+요구사항(이슈 #9):
+    - 디렉토리 트리 섹션과 프로젝트 메타데이터 요약 섹션을 포함한다.
+    - 1 MB 초과 파일은 본문 없이 경로/크기만 표시한다.
+    - 바이너리 파일도 본문 없이 메타데이터만 표시한다.
+    - Ollama 가 생성한 자연어 요약(있을 경우) 을 별도 섹션으로 추가한다.
+
+설계 메모:
+    - SRP: 본 모듈은 데이터 -> 텍스트 변환만 담당한다. I/O 는 호출부의 책임.
+    - 표준 라이브러리만 사용한다.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from sicode.init.scanner import (
+    DirectoryEntry,
+    FileEntry,
+    MetadataFile,
+    ProjectSnapshot,
+)
+
+
+#: 코드 블록 안에서 펜스 충돌을 피하기 위해 본문 ``\`\`\``` 를 치환할 마커.
+_FENCE_REPLACEMENT: str = "```"
+
+
+def render_markdown(
+    snapshot: ProjectSnapshot,
+    *,
+    llm_summary: Optional[str] = None,
+) -> str:
+    """:class:`ProjectSnapshot` 을 마크다운 문자열로 직렬화한다.
+
+    Args:
+        snapshot: 정적 스캔 결과.
+        llm_summary: Ollama 가 생성한 자연어 요약(없으면 ``None``).
+
+    Returns:
+        마크다운 문자열. 끝에 개행이 포함된다.
+    """
+    lines: List[str] = []
+    lines.append("# SICODE Project Snapshot")
+    lines.append("")
+    lines.append(f"- Root: `{snapshot.root}`")
+    lines.append(f"- Max depth: {snapshot.max_depth}")
+    lines.append(
+        f"- Max inline file size: {_format_bytes(snapshot.max_file_bytes)}"
+    )
+    lines.append("")
+
+    lines.append("## Directory Tree")
+    lines.append("")
+    lines.append("```")
+    lines.extend(_render_tree_lines(snapshot.tree))
+    lines.append("```")
+    lines.append("")
+
+    lines.append("## Project Metadata")
+    lines.append("")
+    if snapshot.metadata_files:
+        for meta in snapshot.metadata_files:
+            lines.extend(_render_metadata_block(meta))
+            lines.append("")
+    else:
+        lines.append("_No project metadata files detected._")
+        lines.append("")
+
+    lines.append("## Skipped & Oversize Files")
+    lines.append("")
+    skipped = list(_collect_skipped_files(snapshot.tree))
+    if skipped:
+        for entry in skipped:
+            reason = []
+            if entry.is_oversize:
+                reason.append(f"oversize ({_format_bytes(entry.size_bytes)})")
+            if entry.is_binary:
+                reason.append("binary")
+            reason_str = ", ".join(reason) if reason else "skipped"
+            lines.append(f"- `{entry.path}` — {reason_str}")
+    else:
+        lines.append("_None._")
+    lines.append("")
+
+    if llm_summary and llm_summary.strip():
+        lines.append("## LLM Summary")
+        lines.append("")
+        lines.append(llm_summary.strip())
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _render_tree_lines(node: DirectoryEntry, prefix: str = "") -> List[str]:
+    """디렉토리 트리를 아스키 트리 형태로 렌더한다 (루트 한 줄 + 들여쓴 자식)."""
+    out: List[str] = []
+    if node.depth == 0:
+        # 루트 자체는 항상 ``.`` 로 표기.
+        out.append(".")
+        out.extend(_render_children(node, prefix=""))
+    else:  # pragma: no cover - 외부에서 비루트 시작 호출은 사용하지 않음
+        out.append(f"{prefix}{node.path}/")
+        out.extend(_render_children(node, prefix=prefix + "  "))
+    return out
+
+
+def _render_children(node: DirectoryEntry, prefix: str) -> List[str]:
+    """노드의 직속 자식들을 알파벳 순서로 렌더한다."""
+    out: List[str] = []
+    # 디렉토리 먼저, 그 다음 파일을 표시 (가독성).
+    for d in node.directories:
+        # 마지막 경로 요소만 트리에 표기.
+        name = d.path.split("/")[-1]
+        suffix = "/  (truncated)" if d.truncated else "/"
+        out.append(f"{prefix}{name}{suffix}")
+        if not d.truncated:
+            out.extend(_render_children(d, prefix=prefix + "  "))
+    for f in node.files:
+        name = f.path.split("/")[-1]
+        marker = ""
+        if f.is_oversize:
+            marker = f"  [oversize {_format_bytes(f.size_bytes)}]"
+        elif f.is_binary:
+            marker = "  [binary]"
+        out.append(f"{prefix}{name}{marker}")
+    return out
+
+
+def _render_metadata_block(meta: MetadataFile) -> List[str]:
+    """메타데이터 파일 한 개를 마크다운 코드 블록으로 렌더."""
+    out: List[str] = []
+    truncated_note = " (truncated)" if meta.truncated else ""
+    out.append(f"### `{meta.path}`{truncated_note}")
+    out.append("")
+    fence = _select_fence(meta.content)
+    language = _language_hint(meta.path)
+    out.append(f"{fence}{language}")
+    out.append(meta.content.rstrip("\n"))
+    out.append(fence)
+    return out
+
+
+def _select_fence(content: str) -> str:
+    r"""본문에 ``\`\`\`` 가 등장하면 한 글자 더 긴 펜스를 사용한다."""
+    if _FENCE_REPLACEMENT not in content:
+        return _FENCE_REPLACEMENT
+    # 본문 안 펜스 길이 + 1 만큼의 백틱을 쓰면 충돌이 나지 않는다.
+    longest = 0
+    run = 0
+    for ch in content:
+        if ch == "`":
+            run += 1
+            longest = max(longest, run)
+        else:
+            run = 0
+    return "`" * max(longest + 1, 3)
+
+
+def _language_hint(path: str) -> str:
+    """파일 확장자/이름 기반 코드 블록 언어 힌트(없으면 빈 문자열)."""
+    lower = path.lower()
+    if lower.endswith(".toml"):
+        return "toml"
+    if lower.endswith(".json"):
+        return "json"
+    if lower.endswith(".md") or lower.endswith(".markdown"):
+        return "markdown"
+    if lower.endswith(".rst"):
+        return "rst"
+    if lower.endswith(".txt"):
+        return ""
+    if lower.endswith(".cfg") or lower.endswith(".ini"):
+        return "ini"
+    if lower.endswith(".py"):
+        return "python"
+    if lower.endswith("/makefile") or lower == "makefile":
+        return "make"
+    return ""
+
+
+def _collect_skipped_files(node: DirectoryEntry) -> "list[FileEntry]":
+    """트리에서 본문이 생략된(바이너리/오버사이즈) 파일만 수집."""
+    out: List[FileEntry] = []
+    _walk_files_skipped(node, out)
+    out.sort(key=lambda f: f.path)
+    return out
+
+
+def _walk_files_skipped(node: DirectoryEntry, sink: List[FileEntry]) -> None:
+    for f in node.files:
+        if f.is_oversize or f.is_binary:
+            sink.append(f)
+    for d in node.directories:
+        _walk_files_skipped(d, sink)
+
+
+def _format_bytes(size: int) -> str:
+    """사람이 읽기 좋은 바이트 표시 (KiB/MiB)."""
+    if size < 1024:
+        return f"{size} B"
+    if size < 1024 * 1024:
+        return f"{size / 1024:.1f} KiB"
+    return f"{size / (1024 * 1024):.2f} MiB"
+
+
+__all__ = ["render_markdown"]

--- a/sicode/init/scanner.py
+++ b/sicode/init/scanner.py
@@ -1,0 +1,406 @@
+"""프로젝트 디렉토리 정적 스캐너.
+
+요구사항(이슈 #9):
+    - ``Path.cwd()`` 를 루트로 하여 디렉토리 트리를 최대 4단계 깊이까지 수집한다.
+    - ``.git/``, ``__pycache__/``, ``*.pyc``, ``.env``, ``*.pem``, ``id_rsa*`` 등
+      보안·노이즈 패턴은 스캔에서 제외한다.
+    - 1 MB 초과 파일 및 텍스트로 판별되지 않는 바이너리 파일은 내용을 읽지 않고
+      메타데이터(경로, 크기) 만 기록한다.
+    - ``pyproject.toml``, ``package.json``, ``README.md``, ``Makefile``, ``*.toml``,
+      ``requirements*.txt`` 등 프로젝트 메타데이터 파일은 내용을 읽어 요약한다.
+
+설계 메모:
+    - SRP: 본 모듈은 파일 시스템에서 정보 수집만 담당한다. 마크다운 렌더링은
+      :mod:`sicode.init.renderer` 가, 명령 처리/저장은 :mod:`sicode.init.command`
+      가 담당한다.
+    - OCP: 깊이/패턴/크기 한도는 모두 함수 인자로 주입할 수 있다. 기본값은 모듈 상수
+      (``DEFAULT_*``) 로 노출한다.
+    - 외부 의존성 없이 표준 라이브러리(``pathlib``, ``fnmatch``, ``os``) 만 사용한다.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+
+#: 기본 최대 깊이. 루트(0) 포함하여 자식 디렉토리는 4단계까지 내려간다.
+DEFAULT_MAX_DEPTH: int = 4
+
+#: 1 MB. 초과 파일은 내용 없이 메타데이터만 남긴다.
+DEFAULT_MAX_FILE_BYTES: int = 1024 * 1024
+
+#: 파일/디렉토리 이름에 적용하는 무시 패턴(``fnmatch`` 스타일).
+#:
+#: 디렉토리 이름과 파일 이름 양쪽에 적용된다. 보안 관련(``.env``, ``*.pem``,
+#: ``id_rsa*``) 항목은 절대 읽히지 않도록 가장 먼저 검사한다.
+DEFAULT_IGNORE_PATTERNS: Tuple[str, ...] = (
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+    "*.pyc",
+    "*.pyo",
+    ".venv",
+    "venv",
+    "node_modules",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    "dist",
+    "build",
+    "*.egg-info",
+    ".env",
+    ".env.*",
+    "*.pem",
+    "*.key",
+    "id_rsa",
+    "id_rsa.*",
+    "id_dsa",
+    "id_ecdsa",
+    "id_ed25519",
+    "*.crt",
+    "*.p12",
+    ".DS_Store",
+)
+
+#: 프로젝트 메타데이터로 인식할 파일 이름 패턴(``fnmatch`` 스타일).
+#:
+#: 매칭된 파일은 본문을 읽어 마크다운 요약 섹션에 포함한다.
+DEFAULT_METADATA_PATTERNS: Tuple[str, ...] = (
+    "pyproject.toml",
+    "package.json",
+    "package-lock.json",
+    "README.md",
+    "README.rst",
+    "Makefile",
+    "*.toml",
+    "requirements*.txt",
+    "setup.py",
+    "setup.cfg",
+    "Pipfile",
+    "Cargo.toml",
+    "go.mod",
+)
+
+#: 메타데이터 파일에서 읽어들일 최대 바이트(렌더 시 잘려도 무방하도록 보수적 한도).
+DEFAULT_METADATA_MAX_BYTES: int = 64 * 1024
+
+
+@dataclass(frozen=True)
+class FileEntry:
+    """파일 항목.
+
+    Attributes:
+        path: 루트로부터의 상대 경로(POSIX 스타일).
+        size_bytes: 바이트 크기. ``stat`` 실패 시 ``0`` 으로 기록될 수 있다.
+        is_binary: 텍스트로 판별되지 않은 경우 ``True``.
+        is_oversize: ``DEFAULT_MAX_FILE_BYTES`` 초과 시 ``True``.
+    """
+
+    path: str
+    size_bytes: int
+    is_binary: bool = False
+    is_oversize: bool = False
+
+
+@dataclass(frozen=True)
+class DirectoryEntry:
+    """디렉토리 트리 노드.
+
+    Attributes:
+        path: 루트로부터의 상대 경로(POSIX 스타일). 루트 자신은 ``"."``.
+        depth: 루트(0) 기준 깊이.
+        directories: 직속 하위 디렉토리.
+        files: 직속 하위 파일.
+        truncated: 깊이 한도를 만나 이 디렉토리의 내용을 더 이상 탐색하지 않은 경우 ``True``.
+    """
+
+    path: str
+    depth: int
+    directories: Tuple["DirectoryEntry", ...] = field(default_factory=tuple)
+    files: Tuple[FileEntry, ...] = field(default_factory=tuple)
+    truncated: bool = False
+
+
+@dataclass(frozen=True)
+class MetadataFile:
+    """프로젝트 메타데이터 파일의 본문 스냅샷.
+
+    Attributes:
+        path: 루트로부터의 상대 경로(POSIX 스타일).
+        content: 텍스트 본문. 길이가 길면 ``truncated=True`` 와 함께 잘릴 수 있다.
+        truncated: ``DEFAULT_METADATA_MAX_BYTES`` 초과로 잘린 경우 ``True``.
+    """
+
+    path: str
+    content: str
+    truncated: bool = False
+
+
+@dataclass(frozen=True)
+class ProjectSnapshot:
+    """정적 스캔 결과 전체를 표현하는 불변 데이터.
+
+    Attributes:
+        root: 스캔 루트의 절대 경로 문자열.
+        tree: 루트 디렉토리 노드.
+        metadata_files: 본문이 함께 수집된 프로젝트 메타데이터 파일 목록.
+        max_depth: 적용된 최대 깊이.
+        max_file_bytes: 본문 수집 임계 크기(바이트).
+    """
+
+    root: str
+    tree: DirectoryEntry
+    metadata_files: Tuple[MetadataFile, ...] = field(default_factory=tuple)
+    max_depth: int = DEFAULT_MAX_DEPTH
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _matches_any(name: str, patterns: Iterable[str]) -> bool:
+    """이름이 ``fnmatch`` 패턴 중 하나에라도 매칭되는지 검사."""
+    for pattern in patterns:
+        if fnmatch.fnmatch(name, pattern):
+            return True
+    return False
+
+
+def _is_probably_binary(path: Path, sample_size: int = 4096) -> bool:
+    """파일의 앞부분을 읽어 NULL 바이트가 포함되어 있으면 바이너리로 판단한다.
+
+    표준 라이브러리만 사용하므로 ``mimetypes`` 보다 간단·확실한 휴리스틱을 채택했다.
+    심볼릭 링크 대상이 사라졌거나 권한 문제로 읽지 못하는 경우는 안전하게 ``True``
+    (바이너리 취급) 로 간주해 본문 수집을 건너뛴다.
+    """
+    try:
+        with path.open("rb") as fh:
+            chunk = fh.read(sample_size)
+    except OSError:
+        return True
+    if not chunk:
+        return False
+    return b"\x00" in chunk
+
+
+def _safe_size(path: Path) -> int:
+    """``stat`` 실패 시 ``0`` 을 돌려주는 안전 헬퍼."""
+    try:
+        return path.stat().st_size
+    except OSError:
+        return 0
+
+
+def _read_text_clipped(path: Path, max_bytes: int) -> Tuple[str, bool]:
+    """텍스트 파일을 최대 ``max_bytes`` 만큼만 읽는다.
+
+    Returns:
+        (본문, ``truncated`` 여부) 튜플. 권한/디코드 실패 시 ``("", False)`` 를 반환한다.
+    """
+    try:
+        with path.open("rb") as fh:
+            data = fh.read(max_bytes + 1)
+    except OSError:
+        return "", False
+
+    truncated = len(data) > max_bytes
+    if truncated:
+        data = data[:max_bytes]
+
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        try:
+            text = data.decode("utf-8", errors="replace")
+        except Exception:  # pragma: no cover - 매우 드문 경로
+            return "", False
+    return text, truncated
+
+
+def _relpath(path: Path, root: Path) -> str:
+    """루트 기준 상대 경로(POSIX 스타일). 루트 자체는 ``"."``."""
+    rel = os.path.relpath(str(path), str(root))
+    if rel == ".":
+        return "."
+    return rel.replace(os.sep, "/")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def scan_project(
+    root: Optional[Path] = None,
+    *,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+    ignore_patterns: Iterable[str] = DEFAULT_IGNORE_PATTERNS,
+    metadata_patterns: Iterable[str] = DEFAULT_METADATA_PATTERNS,
+    metadata_max_bytes: int = DEFAULT_METADATA_MAX_BYTES,
+) -> ProjectSnapshot:
+    """루트 디렉토리를 스캔해 :class:`ProjectSnapshot` 을 반환한다.
+
+    Args:
+        root: 스캔 루트. ``None`` 이면 :func:`Path.cwd` 사용.
+        max_depth: 루트(0) 기준 최대 깊이. ``4`` 면 루트의 4단계 자식까지 내려간다.
+        max_file_bytes: 본문 수집 임계 크기. 초과 파일은 메타데이터만 기록한다.
+        ignore_patterns: 무시할 이름 패턴(``fnmatch``). 디렉토리·파일 모두에 적용.
+        metadata_patterns: 본문을 읽어 요약 섹션에 포함할 파일 이름 패턴.
+        metadata_max_bytes: 메타데이터 파일 본문 수집 한도(바이트).
+
+    Returns:
+        스냅샷.
+    """
+    if root is None:
+        root = Path.cwd()
+    root = root.resolve()
+    ignore_tuple = tuple(ignore_patterns)
+    metadata_tuple = tuple(metadata_patterns)
+
+    metadata_files: List[MetadataFile] = []
+    tree = _scan_directory(
+        path=root,
+        root=root,
+        depth=0,
+        max_depth=max_depth,
+        max_file_bytes=max_file_bytes,
+        ignore_patterns=ignore_tuple,
+        metadata_patterns=metadata_tuple,
+        metadata_max_bytes=metadata_max_bytes,
+        metadata_sink=metadata_files,
+    )
+    metadata_files.sort(key=lambda m: m.path)
+    return ProjectSnapshot(
+        root=str(root),
+        tree=tree,
+        metadata_files=tuple(metadata_files),
+        max_depth=max_depth,
+        max_file_bytes=max_file_bytes,
+    )
+
+
+def _scan_directory(
+    *,
+    path: Path,
+    root: Path,
+    depth: int,
+    max_depth: int,
+    max_file_bytes: int,
+    ignore_patterns: Tuple[str, ...],
+    metadata_patterns: Tuple[str, ...],
+    metadata_max_bytes: int,
+    metadata_sink: List[MetadataFile],
+) -> DirectoryEntry:
+    """단일 디렉토리를 스캔해 :class:`DirectoryEntry` 를 만든다."""
+    rel = _relpath(path, root)
+
+    # 깊이 한도 초과 디렉토리는 노드만 생성하고 내려가지 않는다.
+    if depth > max_depth:
+        return DirectoryEntry(
+            path=rel,
+            depth=depth,
+            directories=(),
+            files=(),
+            truncated=True,
+        )
+
+    try:
+        children = sorted(path.iterdir(), key=lambda p: p.name)
+    except OSError:
+        return DirectoryEntry(path=rel, depth=depth, truncated=False)
+
+    sub_dirs: List[DirectoryEntry] = []
+    files: List[FileEntry] = []
+    for child in children:
+        name = child.name
+        # 이름 기반 무시 패턴은 디렉토리/파일 모두에 동일 적용한다.
+        if _matches_any(name, ignore_patterns):
+            continue
+
+        if child.is_symlink():
+            # 심볼릭 링크는 따라가지 않는다(루프/외부 노출 방지).
+            # 파일 메타데이터만 기록한다.
+            files.append(
+                FileEntry(
+                    path=_relpath(child, root),
+                    size_bytes=_safe_size(child),
+                    is_binary=True,
+                    is_oversize=False,
+                )
+            )
+            continue
+
+        if child.is_dir():
+            sub_dirs.append(
+                _scan_directory(
+                    path=child,
+                    root=root,
+                    depth=depth + 1,
+                    max_depth=max_depth,
+                    max_file_bytes=max_file_bytes,
+                    ignore_patterns=ignore_patterns,
+                    metadata_patterns=metadata_patterns,
+                    metadata_max_bytes=metadata_max_bytes,
+                    metadata_sink=metadata_sink,
+                )
+            )
+            continue
+
+        if child.is_file():
+            size = _safe_size(child)
+            is_oversize = size > max_file_bytes
+            is_binary = False if is_oversize else _is_probably_binary(child)
+            files.append(
+                FileEntry(
+                    path=_relpath(child, root),
+                    size_bytes=size,
+                    is_binary=is_binary,
+                    is_oversize=is_oversize,
+                )
+            )
+            # 메타데이터 후보는 무시 패턴을 통과하고 크기/바이너리 제약을 만족한 경우에만 읽는다.
+            if (
+                not is_oversize
+                and not is_binary
+                and _matches_any(name, metadata_patterns)
+            ):
+                content, truncated = _read_text_clipped(child, metadata_max_bytes)
+                if content:
+                    metadata_sink.append(
+                        MetadataFile(
+                            path=_relpath(child, root),
+                            content=content,
+                            truncated=truncated,
+                        )
+                    )
+
+    return DirectoryEntry(
+        path=rel,
+        depth=depth,
+        directories=tuple(sub_dirs),
+        files=tuple(files),
+        truncated=False,
+    )
+
+
+__all__ = [
+    "DEFAULT_IGNORE_PATTERNS",
+    "DEFAULT_MAX_DEPTH",
+    "DEFAULT_MAX_FILE_BYTES",
+    "DEFAULT_METADATA_MAX_BYTES",
+    "DEFAULT_METADATA_PATTERNS",
+    "DirectoryEntry",
+    "FileEntry",
+    "MetadataFile",
+    "ProjectSnapshot",
+    "scan_project",
+]

--- a/sicode/init/scanner.py
+++ b/sicode/init/scanner.py
@@ -76,7 +76,8 @@ DEFAULT_IGNORE_PATTERNS: Tuple[str, ...] = (
     ".netrc",
     ".npmrc",
     ".pypirc",
-    "*.aws",
+    # AWS 자격증명은 디렉토리 ``~/.aws/`` 안에 위치하므로 ``.aws`` 패턴이면 충분.
+    # ``*.aws`` 는 가공의 ``foo.aws`` 같은 노이즈만 잡으므로 제거(리뷰 라운드 3 정정).
     ".aws",
     ".DS_Store",
 )

--- a/sicode/init/scanner.py
+++ b/sicode/init/scanner.py
@@ -54,17 +54,30 @@ DEFAULT_IGNORE_PATTERNS: Tuple[str, ...] = (
     "dist",
     "build",
     "*.egg-info",
+    # 환경/시크릿 (보수적 디폴트). 이름 패턴은 ``fnmatch`` 스타일이며 디렉토리·
+    # 파일 양쪽에 적용된다. 정확한 이름 외에 ``*`` 와일드카드로 변형까지 차단.
     ".env",
     ".env.*",
     "*.pem",
     "*.key",
-    "id_rsa",
-    "id_rsa.*",
-    "id_dsa",
-    "id_ecdsa",
-    "id_ed25519",
     "*.crt",
     "*.p12",
+    "*.pfx",
+    "*.jks",
+    "*.keystore",
+    "id_rsa*",  # id_rsa, id_rsa.pub, id_rsa_legacy 등 모든 변형
+    "id_dsa*",
+    "id_ecdsa*",
+    "id_ed25519*",
+    "secrets.*",
+    "secret.*",
+    "credentials*",
+    "*.netrc",
+    ".netrc",
+    ".npmrc",
+    ".pypirc",
+    "*.aws",
+    ".aws",
     ".DS_Store",
 )
 
@@ -252,6 +265,9 @@ def scan_project(
     Args:
         root: 스캔 루트. ``None`` 이면 :func:`Path.cwd` 사용.
         max_depth: 루트(0) 기준 최대 깊이. ``4`` 면 루트의 4단계 자식까지 내려간다.
+            한도 + 1 깊이의 디렉토리는 노드 자체는 트리에 등장하지만 자식 없이
+            ``truncated=True`` sentinel 로만 노출되어 "여기서 잘렸음" 을 표시한다.
+            한도 + 2 이상 깊이의 노드는 일절 트리에 포함되지 않는다.
         max_file_bytes: 본문 수집 임계 크기. 초과 파일은 메타데이터만 기록한다.
         ignore_patterns: 무시할 이름 패턴(``fnmatch``). 디렉토리·파일 모두에 적용.
         metadata_patterns: 본문을 읽어 요약 섹션에 포함할 파일 이름 패턴.

--- a/tests/init/test_command.py
+++ b/tests/init/test_command.py
@@ -1,0 +1,231 @@
+"""``sicode.init.command.InitCommand`` 단위 테스트.
+
+검증 범위:
+    - scanner / renderer 를 mock 으로 주입했을 때 파일 저장과 REPL 출력이 올바르다.
+    - ``SICODE.md`` 가 이미 존재하면 ``SICODE.md.bak`` 을 만들고 그 사실을 출력한다.
+    - Ollama summarizer 예외는 흡수되어 정적 분석 결과만으로 정상 완료된다.
+    - REPL 통합: ``register_default_commands`` 후 ``/init`` 입력으로 명령이 실행된다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+from sicode.commands import (
+    register_default_commands,
+)
+from sicode.commands.base import CommandAction, ReplContext
+from sicode.commands.registry import SlashCommandRegistry, dispatch_command
+from sicode.init.command import (
+    DEFAULT_BACKUP_SUFFIX,
+    DEFAULT_OUTPUT_FILENAME,
+    InitCommand,
+    WriteResult,
+    write_snapshot_file,
+)
+from sicode.init.scanner import (
+    DirectoryEntry,
+    ProjectSnapshot,
+)
+from sicode.repl import run_repl_with_inputs
+from tests.conftest import EchoMode
+
+
+def _empty_snapshot(root: Path) -> ProjectSnapshot:
+    return ProjectSnapshot(
+        root=str(root),
+        tree=DirectoryEntry(path=".", depth=0),
+        metadata_files=(),
+        max_depth=4,
+        max_file_bytes=1024 * 1024,
+    )
+
+
+class TestWriteSnapshotFile:
+    def test_writes_when_no_existing_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "SICODE.md"
+        result = write_snapshot_file("hello", target)
+        assert target.exists()
+        assert target.read_text(encoding="utf-8") == "hello"
+        assert result.output_path == target
+        assert result.backup_path is None
+
+    def test_creates_backup_when_existing(self, tmp_path: Path) -> None:
+        target = tmp_path / "SICODE.md"
+        target.write_text("old", encoding="utf-8")
+        result = write_snapshot_file("new", target)
+        assert target.read_text(encoding="utf-8") == "new"
+        backup = tmp_path / ("SICODE.md" + DEFAULT_BACKUP_SUFFIX)
+        assert backup.exists()
+        assert backup.read_text(encoding="utf-8") == "old"
+        assert result.backup_path == backup
+
+
+class TestInitCommandUnit:
+    def test_uses_injected_scanner_and_renderer(self, tmp_path: Path) -> None:
+        captured_scanned: list[Path] = []
+        captured_render_args: list[tuple[ProjectSnapshot, Optional[str]]] = []
+        write_calls: list[tuple[str, Path]] = []
+
+        def fake_scanner(root: Path) -> ProjectSnapshot:
+            captured_scanned.append(root)
+            return _empty_snapshot(root)
+
+        def fake_renderer(snap: ProjectSnapshot, summary: Optional[str]) -> str:
+            captured_render_args.append((snap, summary))
+            return "RENDERED"
+
+        def fake_writer(markdown: str, path: Path) -> WriteResult:
+            write_calls.append((markdown, path))
+            return WriteResult(output_path=path, backup_path=None)
+
+        cmd = InitCommand(
+            scanner=fake_scanner,
+            renderer=fake_renderer,
+            writer=fake_writer,
+            cwd_fn=lambda: tmp_path,
+        )
+        result = cmd.execute(ReplContext())
+        assert result.action is CommandAction.CONTINUE
+        assert captured_scanned == [tmp_path.resolve()]
+        assert captured_render_args[0][1] is None  # no summary
+        assert write_calls[0][0] == "RENDERED"
+        assert write_calls[0][1] == (tmp_path / DEFAULT_OUTPUT_FILENAME).resolve()
+        assert "Saved project snapshot to:" in result.output
+        assert str((tmp_path / DEFAULT_OUTPUT_FILENAME).resolve()) in result.output
+
+    def test_reports_backup_in_output(self, tmp_path: Path) -> None:
+        backup = tmp_path / "SICODE.md.bak"
+
+        def fake_writer(markdown: str, path: Path) -> WriteResult:
+            return WriteResult(output_path=path, backup_path=backup)
+
+        cmd = InitCommand(
+            scanner=lambda r: _empty_snapshot(r),
+            renderer=lambda s, l: "x",
+            writer=fake_writer,
+            cwd_fn=lambda: tmp_path,
+        )
+        result = cmd.execute(ReplContext())
+        assert "Existing file backed up to:" in result.output
+        assert str(backup) in result.output
+
+    def test_summarizer_exception_is_swallowed(self, tmp_path: Path) -> None:
+        renders: list[Optional[str]] = []
+
+        def boom(snap: ProjectSnapshot) -> str:
+            raise RuntimeError("ollama down")
+
+        def fake_renderer(snap: ProjectSnapshot, summary: Optional[str]) -> str:
+            renders.append(summary)
+            return "OK"
+
+        cmd = InitCommand(
+            scanner=lambda r: _empty_snapshot(r),
+            renderer=fake_renderer,
+            writer=lambda md, p: WriteResult(output_path=p, backup_path=None),
+            summarizer=boom,
+            cwd_fn=lambda: tmp_path,
+        )
+        result = cmd.execute(ReplContext())
+        assert result.action is CommandAction.CONTINUE
+        # 요약 실패는 출력에 노출되지 않고, 렌더러에 None 이 전달된다.
+        assert renders == [None]
+        assert "Saved project snapshot to:" in result.output
+        assert "LLM summary" not in result.output
+
+    def test_summarizer_success_includes_in_render_and_message(
+        self, tmp_path: Path
+    ) -> None:
+        renders: list[Optional[str]] = []
+
+        def good(snap: ProjectSnapshot) -> str:
+            return "Project does X."
+
+        def fake_renderer(snap: ProjectSnapshot, summary: Optional[str]) -> str:
+            renders.append(summary)
+            return "OK"
+
+        cmd = InitCommand(
+            scanner=lambda r: _empty_snapshot(r),
+            renderer=fake_renderer,
+            writer=lambda md, p: WriteResult(output_path=p, backup_path=None),
+            summarizer=good,
+            cwd_fn=lambda: tmp_path,
+        )
+        result = cmd.execute(ReplContext())
+        assert renders == ["Project does X."]
+        assert "Included LLM summary" in result.output
+
+    def test_summarizer_returns_blank_is_treated_as_none(self, tmp_path: Path) -> None:
+        renders: list[Optional[str]] = []
+
+        cmd = InitCommand(
+            scanner=lambda r: _empty_snapshot(r),
+            renderer=lambda s, l: (renders.append(l) or "OK"),
+            writer=lambda md, p: WriteResult(output_path=p, backup_path=None),
+            summarizer=lambda s: "   \n   ",
+            cwd_fn=lambda: tmp_path,
+        )
+        result = cmd.execute(ReplContext())
+        assert renders == [None]
+        assert "LLM summary" not in result.output
+
+
+class TestInitCommandIntegration:
+    def test_end_to_end_writes_real_file(self, tmp_path: Path) -> None:
+        # 실제 scanner/renderer/writer 사용. tmp 디렉토리에 파일 몇 개를 만들어둔다.
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "demo"\n', encoding="utf-8"
+        )
+        (tmp_path / "main.py").write_text("print('hi')\n", encoding="utf-8")
+
+        cmd = InitCommand(cwd_fn=lambda: tmp_path)
+        result = cmd.execute(ReplContext())
+        out_path = (tmp_path / "SICODE.md").resolve()
+        assert out_path.exists()
+        assert "## Directory Tree" in out_path.read_text(encoding="utf-8")
+        assert str(out_path) in result.output
+
+    def test_existing_file_backup_flow(self, tmp_path: Path) -> None:
+        target = tmp_path / "SICODE.md"
+        target.write_text("OLD CONTENT", encoding="utf-8")
+
+        cmd = InitCommand(cwd_fn=lambda: tmp_path)
+        result = cmd.execute(ReplContext())
+
+        backup = tmp_path / "SICODE.md.bak"
+        assert backup.exists()
+        assert backup.read_text(encoding="utf-8") == "OLD CONTENT"
+        assert "Existing file backed up to:" in result.output
+        assert str(backup) in result.output
+
+    def test_repl_dispatch_via_slash_init(self, tmp_path: Path) -> None:
+        # 별도 레지스트리를 만들어 InitCommand 만 등록하고 dispatch_command 로 검증.
+        reg = SlashCommandRegistry()
+        cmd = InitCommand(cwd_fn=lambda: tmp_path)
+        reg.register(cmd)
+        result = dispatch_command("/init", registry=reg)
+        assert result.action is CommandAction.CONTINUE
+        assert (tmp_path / "SICODE.md").exists()
+        assert "Saved project snapshot to:" in result.output
+
+    def test_register_default_commands_includes_init(self) -> None:
+        reg = SlashCommandRegistry()
+        register_default_commands(registry=reg)
+        names = [c.name for c in reg.commands()]
+        assert "init" in names
+
+    def test_repl_run_with_slash_init_does_not_call_mode_handle(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # Path.cwd 를 tmp_path 로 고정시키고, 기본 등록 절차로 명령을 실행.
+        monkeypatch.chdir(tmp_path)
+        register_default_commands()
+        mode = EchoMode()
+        outputs = run_repl_with_inputs(mode, ["/init", "/exit"])
+        assert mode.calls == []
+        joined = "\n".join(outputs)
+        assert "Saved project snapshot to:" in joined
+        assert (tmp_path / "SICODE.md").exists()

--- a/tests/init/test_command.py
+++ b/tests/init/test_command.py
@@ -330,3 +330,88 @@ class TestInitCommandIntegration:
         joined = "\n".join(outputs)
         assert "Saved project snapshot to:" in joined
         assert (tmp_path / "SICODE.md").exists()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="symlink 정책 테스트는 POSIX 환경 가정. Windows 는 권한 모델이 다르다.",
+)
+class TestInitCommandSymlinkSafetyIntegration:
+    """``InitCommand.execute`` end-to-end 보안 회귀 테스트 (라운드 3).
+
+    리뷰 라운드 2 [Critical]:
+        ``InitCommand.execute`` 가 ``output_path = (root / filename).resolve()`` 로
+        심볼릭 링크를 미리 풀어 writer 에 넘기던 시기가 있었다. 그 결과
+        ``write_snapshot_file`` 의 ``is_symlink`` 단위 보안은 통과해도,
+        실제 통합 호출 경로에서는 외부 파일이 백업/덮어쓰기 당하는 데이터
+        유출/임의 변조 결함이 재현됐다. 본 테스트는 이 통합 경로 회귀를 막는다.
+    """
+
+    def test_execute_refuses_when_sicode_md_is_symlink_to_external_file(
+        self, tmp_path: Path
+    ) -> None:
+        # 외부 디렉토리에 "민감" 파일.
+        external_dir = tmp_path / "external_dir"
+        external_dir.mkdir()
+        external = external_dir / "external_secret.txt"
+        external.write_text("SECRET CONTENT", encoding="utf-8")
+
+        # cwd 는 별도 디렉토리. 그 안의 SICODE.md 가 외부 파일을 가리키는 symlink.
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        target = cwd / "SICODE.md"
+        os.symlink(str(external), str(target))
+        assert target.is_symlink()
+
+        cmd = InitCommand(cwd_fn=lambda: cwd)
+
+        # InitCommand 가 resolve() 로 심볼릭을 풀면 writer 의 검사가 우회되어
+        # CommandResult 가 정상 반환되는 결함이 있었다. 이제는 반드시 거부.
+        with pytest.raises(UnsafeOutputPathError):
+            cmd.execute(ReplContext())
+
+        # 가장 중요한 사후 조건: 외부 파일은 어떤 식으로도 변조되거나 백업되지 않음.
+        assert external.read_text(encoding="utf-8") == "SECRET CONTENT"
+        # 외부 디렉토리에 백업 파일이 생성되어선 절대 안 된다(데이터 유출 경로 차단).
+        assert not (external_dir / "external_secret.txt.bak").exists()
+        # cwd 디렉토리에도 SICODE.md.bak 가 생기면 안 된다.
+        assert not (cwd / "SICODE.md.bak").exists()
+        # 심볼릭 링크 자체는 우리가 손대지 않으므로 그대로 유지.
+        assert target.is_symlink()
+
+    def test_execute_refuses_when_sicode_md_is_broken_symlink(
+        self, tmp_path: Path
+    ) -> None:
+        # 깨진 심볼릭 링크여도 InitCommand 통합 경로에서 거부되어야 한다.
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        target = cwd / "SICODE.md"
+        os.symlink(str(tmp_path / "does_not_exist"), str(target))
+
+        cmd = InitCommand(cwd_fn=lambda: cwd)
+        with pytest.raises(UnsafeOutputPathError):
+            cmd.execute(ReplContext())
+
+        # 백업 / 실제 파일 어느 쪽도 만들어져선 안 됨.
+        assert not (cwd / "SICODE.md.bak").exists()
+        # 링크 자체는 그대로.
+        assert target.is_symlink()
+
+    def test_execute_normal_when_cwd_parent_is_symlink_dir(
+        self, tmp_path: Path
+    ) -> None:
+        # cwd 부모 디렉토리가 심볼릭 링크여도 (e.g. macOS 의 /tmp -> /private/tmp)
+        # leaf SICODE.md 가 실제 파일이라면 정상 동작해야 한다.
+        # ``Path.absolute()`` 는 심볼릭을 풀지 않으므로 leaf 만 체크된다.
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        link_dir = tmp_path / "link"
+        os.symlink(str(real_dir), str(link_dir))
+
+        # symlink 디렉토리를 cwd 로 사용.
+        cmd = InitCommand(cwd_fn=lambda: link_dir)
+        result = cmd.execute(ReplContext())
+        # 정상 완료. 실제 파일이 link_dir(혹은 real_dir) 안에 생긴다.
+        assert "Saved project snapshot to:" in result.output
+        assert (link_dir / "SICODE.md").exists()
+        assert (real_dir / "SICODE.md").exists()

--- a/tests/init/test_command.py
+++ b/tests/init/test_command.py
@@ -9,6 +9,11 @@
 
 from __future__ import annotations
 
+import os
+import sys
+
+import pytest
+
 from pathlib import Path
 from typing import List, Optional
 
@@ -21,6 +26,7 @@ from sicode.init.command import (
     DEFAULT_BACKUP_SUFFIX,
     DEFAULT_OUTPUT_FILENAME,
     InitCommand,
+    UnsafeOutputPathError,
     WriteResult,
     write_snapshot_file,
 )
@@ -60,6 +66,101 @@ class TestWriteSnapshotFile:
         assert backup.exists()
         assert backup.read_text(encoding="utf-8") == "old"
         assert result.backup_path == backup
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="symlink 정책 테스트는 POSIX 환경 가정. Windows 는 권한 모델이 다르다.",
+)
+class TestWriteSnapshotFileSymlinkSafety:
+    """``write_snapshot_file`` 의 심볼릭 링크 보안 회귀 테스트.
+
+    PR #12 리뷰 라운드 2 [Critical]: SICODE.md 자리에 외부 파일을 가리키는
+    심볼릭 링크가 있을 때 ``shutil.copy2`` + ``Path.write_text`` 가 링크를
+    그대로 따라가 (1) 외부 파일 내용이 ``SICODE.md.bak`` 로 유출되고
+    (2) 외부 파일이 마크다운으로 덮어쓰이는 결함이 있었다. 본 테스트는
+    이 회귀를 영구적으로 막는다.
+    """
+
+    def test_refuses_when_target_is_symlink_to_external_file(
+        self, tmp_path: Path
+    ) -> None:
+        # 외부 "민감" 파일 - 절대로 백업/덮어쓰기되어선 안 됨.
+        external = tmp_path / "external_secret.txt"
+        external.write_text("SECRET CONTENT", encoding="utf-8")
+
+        # SICODE.md 자리에 외부 파일을 가리키는 심볼릭 링크 배치.
+        target = tmp_path / "SICODE.md"
+        os.symlink(str(external), str(target))
+        assert target.is_symlink()
+
+        with pytest.raises(UnsafeOutputPathError):
+            write_snapshot_file("new content", target)
+
+        # 외부 파일 내용은 그대로 보존되어야 한다(데이터 유출/변조 방지).
+        assert external.read_text(encoding="utf-8") == "SECRET CONTENT"
+        # 백업 파일이 만들어져선 안 된다.
+        backup = tmp_path / ("SICODE.md" + DEFAULT_BACKUP_SUFFIX)
+        assert not backup.exists()
+        # 링크 자체도 그대로 유지(우리가 건드리지 않음).
+        assert target.is_symlink()
+
+    def test_refuses_when_target_is_symlink_even_to_nonexistent(
+        self, tmp_path: Path
+    ) -> None:
+        # 깨진 심볼릭 링크여도 정책상 거부.
+        target = tmp_path / "SICODE.md"
+        os.symlink(str(tmp_path / "does_not_exist"), str(target))
+
+        with pytest.raises(UnsafeOutputPathError):
+            write_snapshot_file("data", target)
+
+        # 백업 / 실제 파일 모두 만들어져선 안 됨.
+        backup = tmp_path / ("SICODE.md" + DEFAULT_BACKUP_SUFFIX)
+        assert not backup.exists()
+        # 링크는 그대로.
+        assert target.is_symlink()
+
+    def test_refuses_when_backup_path_is_symlink(self, tmp_path: Path) -> None:
+        # SICODE.md 는 일반 파일, SICODE.md.bak 자리가 외부를 가리키는 심볼릭 링크.
+        # 이 경우 백업이 외부 파일을 덮어쓰는 식으로 변조하면 안 된다.
+        external = tmp_path / "external.txt"
+        external.write_text("EXTERNAL", encoding="utf-8")
+
+        target = tmp_path / "SICODE.md"
+        target.write_text("OLD", encoding="utf-8")
+        backup = tmp_path / ("SICODE.md" + DEFAULT_BACKUP_SUFFIX)
+        os.symlink(str(external), str(backup))
+        assert backup.is_symlink()
+
+        with pytest.raises(UnsafeOutputPathError):
+            write_snapshot_file("NEW", target)
+
+        # 외부 파일은 변조되지 않아야 함.
+        assert external.read_text(encoding="utf-8") == "EXTERNAL"
+        # 원본 파일도 변하지 않아야 함(거부 후엔 어떤 쓰기도 일어나지 않는다).
+        assert target.read_text(encoding="utf-8") == "OLD"
+        # 백업 링크는 그대로.
+        assert backup.is_symlink()
+
+    def test_normal_flow_still_works_alongside_unrelated_symlinks(
+        self, tmp_path: Path
+    ) -> None:
+        # 같은 디렉토리에 무관한 심볼릭 링크가 있어도 정상 흐름은 영향받지 않음.
+        unrelated_target = tmp_path / "unrelated.txt"
+        unrelated_target.write_text("unrelated", encoding="utf-8")
+        os.symlink(str(unrelated_target), str(tmp_path / "unrelated.lnk"))
+
+        target = tmp_path / "SICODE.md"
+        target.write_text("OLD", encoding="utf-8")
+        result = write_snapshot_file("NEW", target)
+        assert target.read_text(encoding="utf-8") == "NEW"
+        backup = tmp_path / ("SICODE.md" + DEFAULT_BACKUP_SUFFIX)
+        assert backup.exists() and not backup.is_symlink()
+        assert backup.read_text(encoding="utf-8") == "OLD"
+        assert result.backup_path == backup
+        # 무관한 외부 파일은 그대로.
+        assert unrelated_target.read_text(encoding="utf-8") == "unrelated"
 
 
 class TestInitCommandUnit:

--- a/tests/init/test_renderer.py
+++ b/tests/init/test_renderer.py
@@ -1,0 +1,133 @@
+r"""``sicode.init.renderer`` 단위 테스트.
+
+검증 범위:
+    - 마크다운 결과에 디렉토리 트리 섹션, 메타데이터 섹션이 포함된다.
+    - 1 MB 초과 파일은 본문 없이 표기된다.
+    - LLM 요약을 인자로 주면 별도 섹션으로 추가된다.
+    - 메타데이터 본문에 ``\`\`\`` 가 포함돼도 깨지지 않게 펜스가 확장된다.
+"""
+
+from __future__ import annotations
+
+from sicode.init.renderer import render_markdown
+from sicode.init.scanner import (
+    DirectoryEntry,
+    FileEntry,
+    MetadataFile,
+    ProjectSnapshot,
+)
+
+
+def _make_snapshot(
+    *,
+    root: str = "/tmp/example",
+    files: "tuple[FileEntry, ...]" = (),
+    sub_dirs: "tuple[DirectoryEntry, ...]" = (),
+    metadata: "tuple[MetadataFile, ...]" = (),
+) -> ProjectSnapshot:
+    tree = DirectoryEntry(
+        path=".",
+        depth=0,
+        directories=sub_dirs,
+        files=files,
+        truncated=False,
+    )
+    return ProjectSnapshot(
+        root=root,
+        tree=tree,
+        metadata_files=metadata,
+        max_depth=4,
+        max_file_bytes=1024 * 1024,
+    )
+
+
+class TestRendererStructure:
+    def test_includes_required_sections(self) -> None:
+        snap = _make_snapshot(
+            files=(FileEntry(path="main.py", size_bytes=42),),
+            metadata=(
+                MetadataFile(path="pyproject.toml", content='[project]\nname = "x"'),
+            ),
+        )
+        md = render_markdown(snap)
+        assert "# SICODE Project Snapshot" in md
+        assert "## Directory Tree" in md
+        assert "## Project Metadata" in md
+        assert "main.py" in md
+        assert "pyproject.toml" in md
+        assert "/tmp/example" in md
+
+    def test_renders_directory_tree_with_subdirs(self) -> None:
+        sub = DirectoryEntry(
+            path="src",
+            depth=1,
+            files=(FileEntry(path="src/app.py", size_bytes=10),),
+        )
+        snap = _make_snapshot(sub_dirs=(sub,))
+        md = render_markdown(snap)
+        # 트리에 src/ 와 app.py 둘 다 등장해야 한다 (디렉토리 라벨에 슬래시 포함).
+        assert "src/" in md
+        assert "app.py" in md
+
+    def test_metadata_section_when_empty(self) -> None:
+        snap = _make_snapshot()
+        md = render_markdown(snap)
+        assert "_No project metadata files detected._" in md
+
+    def test_skipped_section_lists_oversize_and_binary(self) -> None:
+        snap = _make_snapshot(
+            files=(
+                FileEntry(
+                    path="huge.log",
+                    size_bytes=2 * 1024 * 1024,
+                    is_binary=False,
+                    is_oversize=True,
+                ),
+                FileEntry(
+                    path="data.bin",
+                    size_bytes=100,
+                    is_binary=True,
+                    is_oversize=False,
+                ),
+                FileEntry(path="ok.py", size_bytes=10),
+            )
+        )
+        md = render_markdown(snap)
+        assert "huge.log" in md
+        assert "oversize" in md
+        assert "data.bin" in md
+        assert "binary" in md
+
+
+class TestRendererLLMSummary:
+    def test_includes_llm_summary_when_provided(self) -> None:
+        snap = _make_snapshot()
+        md = render_markdown(snap, llm_summary="This is a Python CLI.")
+        assert "## LLM Summary" in md
+        assert "This is a Python CLI." in md
+
+    def test_omits_llm_summary_when_none(self) -> None:
+        snap = _make_snapshot()
+        md = render_markdown(snap, llm_summary=None)
+        assert "## LLM Summary" not in md
+
+    def test_omits_llm_summary_when_blank(self) -> None:
+        snap = _make_snapshot()
+        md = render_markdown(snap, llm_summary="   \n  ")
+        # 공백만 있는 요약은 호출부 정규화 외에도 렌더러 스스로 섹션을 만들지 않는다.
+        assert "## LLM Summary" not in md
+
+
+class TestRendererFenceEscaping:
+    def test_metadata_content_with_backticks_does_not_break_fences(self) -> None:
+        # 메타데이터 본문 안에 ``` 가 포함되면 펜스를 더 길게 만든다.
+        meta = MetadataFile(
+            path="README.md",
+            content="example: ```python\nprint('x')\n```\n",
+        )
+        snap = _make_snapshot(metadata=(meta,))
+        md = render_markdown(snap)
+        # 외곽 펜스는 본문보다 더 긴 백틱을 사용해야 한다.
+        assert "````" in md  # 4-백틱 펜스
+        # 본문이 그대로 보존되어 있어야 한다.
+        assert "print('x')" in md

--- a/tests/init/test_scanner.py
+++ b/tests/init/test_scanner.py
@@ -1,0 +1,209 @@
+"""``sicode.init.scanner`` 단위 테스트.
+
+검증 범위:
+    - 깊이 한도 (``max_depth``): 4단계 초과는 트리에 포함되지 않는다.
+    - 무시 패턴 (``.git``, ``__pycache__``, ``.env``, ``*.pem``, ``id_rsa*``).
+    - 1 MB 초과 파일: 본문 미수집, 메타데이터(``is_oversize=True``) 만 기록.
+    - 바이너리 파일: NULL 바이트 포함 시 ``is_binary=True``.
+    - 메타데이터 파일(``pyproject.toml`` 등) 본문 수집.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sicode.init.scanner import (
+    DEFAULT_MAX_DEPTH,
+    DEFAULT_MAX_FILE_BYTES,
+    DirectoryEntry,
+    FileEntry,
+    ProjectSnapshot,
+    scan_project,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _all_paths(node: DirectoryEntry) -> "list[str]":
+    """트리에 포함된 모든 디렉토리/파일의 상대 경로(루트 ``.`` 제외)."""
+    out: list[str] = []
+    for d in node.directories:
+        out.append(d.path)
+        out.extend(_all_paths(d))
+    for f in node.files:
+        out.append(f.path)
+    return out
+
+
+def _find_file(node: DirectoryEntry, rel_path: str) -> "FileEntry | None":
+    if node.path == rel_path:  # pragma: no cover - 루트 자체는 파일이 아님
+        return None
+    for f in node.files:
+        if f.path == rel_path:
+            return f
+    for d in node.directories:
+        found = _find_file(d, rel_path)
+        if found is not None:
+            return found
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestScannerDepthLimit:
+    def test_excludes_files_beyond_max_depth(self, tmp_path: Path) -> None:
+        # 5단계 깊이 트리: tmp_path/d1/d2/d3/d4/d5/leaf.txt (루트=0, leaf=6)
+        deep = tmp_path
+        for i in range(1, 7):
+            deep = deep / f"d{i}"
+        deep.mkdir(parents=True)
+        leaf = deep / "leaf.txt"
+        leaf.write_text("hello", encoding="utf-8")
+
+        # max_depth=4 이면 d4 까지 노출, d5 이후는 truncated 로 표시되거나 미포함.
+        snap = scan_project(tmp_path, max_depth=4)
+        all_paths = _all_paths(snap.tree)
+        # leaf 의 전체 경로는 절대 포함되어선 안 된다(깊이 6이라 4단계 초과).
+        assert all(not p.endswith("leaf.txt") for p in all_paths)
+        # d4 까지는 트리에 등장한다.
+        assert any(p.endswith("d4") for p in all_paths)
+
+    def test_truncated_marker_on_depth_boundary(self, tmp_path: Path) -> None:
+        # depth=1 까지만 허용하면 루트의 자식 디렉토리가 truncated=True 로 노출된다.
+        (tmp_path / "child").mkdir()
+        (tmp_path / "child" / "inner").mkdir()
+        snap = scan_project(tmp_path, max_depth=1)
+        # 루트 -> child(depth=1) 까지 보임. inner(depth=2) 는 노출되지 않는다.
+        child = next(d for d in snap.tree.directories if d.path == "child")
+        assert child.depth == 1
+        # inner(depth=2)는 max_depth=1 이므로 child 의 children 도 채워지지 않는다.
+        # _scan_directory 는 depth>max_depth 일 때만 truncated=True 를 set 한다.
+        # depth==max_depth(=1) 이면 자식까지는 보지만 그 자식의 자식은 깊이 2가 되어
+        # 다음 재귀에서 depth>max_depth 가 되어 truncated=True 로 등록된다.
+        inner = next(d for d in child.directories if d.path == "child/inner")
+        assert inner.truncated is True
+        assert inner.directories == ()
+        assert inner.files == ()
+
+
+class TestScannerIgnorePatterns:
+    def test_skips_dot_git_and_pycache(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".git" / "HEAD").write_text("ref", encoding="utf-8")
+        (tmp_path / "__pycache__").mkdir()
+        (tmp_path / "__pycache__" / "x.cpython-39.pyc").write_bytes(b"\x00\x01")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text("print('hi')", encoding="utf-8")
+
+        snap = scan_project(tmp_path)
+        all_paths = _all_paths(snap.tree)
+        assert ".git" not in all_paths
+        assert "__pycache__" not in all_paths
+        # 정상 파일은 포함되어야 함
+        assert "src/main.py" in all_paths
+
+    def test_skips_secrets_env_and_pem_and_id_rsa(self, tmp_path: Path) -> None:
+        (tmp_path / ".env").write_text("SECRET=1", encoding="utf-8")
+        (tmp_path / "server.pem").write_text("-----BEGIN-----", encoding="utf-8")
+        (tmp_path / "id_rsa").write_text("priv", encoding="utf-8")
+        (tmp_path / "id_rsa.pub").write_text("pub", encoding="utf-8")
+        (tmp_path / "keep.txt").write_text("ok", encoding="utf-8")
+
+        snap = scan_project(tmp_path)
+        names = {p.split("/")[-1] for p in _all_paths(snap.tree)}
+        assert ".env" not in names
+        assert "server.pem" not in names
+        assert "id_rsa" not in names
+        assert "id_rsa.pub" not in names
+        assert "keep.txt" in names
+
+    def test_ignored_files_do_not_appear_in_metadata(self, tmp_path: Path) -> None:
+        # 보안 파일이 우연히 메타데이터 패턴과 겹쳐도 포함되어선 안 됨(.env 와 .toml 등은
+        # 이름이 다르니, 여기서는 ``.env`` 만 빠지는지 확인).
+        (tmp_path / ".env").write_text("SECRET=1", encoding="utf-8")
+        snap = scan_project(tmp_path)
+        for meta in snap.metadata_files:
+            assert ".env" not in meta.path
+
+
+class TestScannerOversize:
+    def test_oversize_file_records_metadata_only(self, tmp_path: Path) -> None:
+        big = tmp_path / "huge.txt"
+        # max_file_bytes=10 으로 임계값을 낮춰 검증
+        big.write_text("a" * 100, encoding="utf-8")
+        snap = scan_project(tmp_path, max_file_bytes=10)
+        entry = _find_file(snap.tree, "huge.txt")
+        assert entry is not None
+        assert entry.is_oversize is True
+        assert entry.size_bytes == 100
+        # 큰 파일은 메타데이터 본문 수집 대상이 아니다 (확장자가 .txt 라도)
+        assert all(meta.path != "huge.txt" for meta in snap.metadata_files)
+
+    def test_oversize_default_threshold_is_one_megabyte(self) -> None:
+        assert DEFAULT_MAX_FILE_BYTES == 1024 * 1024
+
+
+class TestScannerBinary:
+    def test_binary_file_marked_and_not_collected(self, tmp_path: Path) -> None:
+        bin_path = tmp_path / "data.bin"
+        bin_path.write_bytes(b"abc\x00\x01\x02more")
+        snap = scan_project(tmp_path)
+        entry = _find_file(snap.tree, "data.bin")
+        assert entry is not None
+        assert entry.is_binary is True
+        assert entry.is_oversize is False
+
+    def test_text_file_not_marked_binary(self, tmp_path: Path) -> None:
+        text = tmp_path / "note.txt"
+        text.write_text("hello world", encoding="utf-8")
+        snap = scan_project(tmp_path)
+        entry = _find_file(snap.tree, "note.txt")
+        assert entry is not None
+        assert entry.is_binary is False
+
+
+class TestScannerMetadataCollection:
+    def test_collects_pyproject_and_readme(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "demo"\n', encoding="utf-8"
+        )
+        (tmp_path / "README.md").write_text("# Demo\n", encoding="utf-8")
+        (tmp_path / "main.py").write_text("print('hi')", encoding="utf-8")
+
+        snap = scan_project(tmp_path)
+        meta_paths = {m.path for m in snap.metadata_files}
+        assert "pyproject.toml" in meta_paths
+        assert "README.md" in meta_paths
+        # main.py 는 메타데이터 패턴에 매칭되지 않음
+        assert "main.py" not in meta_paths
+
+        py = next(m for m in snap.metadata_files if m.path == "pyproject.toml")
+        assert "demo" in py.content
+        assert py.truncated is False
+
+    def test_metadata_truncates_oversize_text(self, tmp_path: Path) -> None:
+        # 메타데이터 한도 미만이라도 절대 한도(max_file_bytes) 넘으면 메타데이터 미수집.
+        # 여기서는 metadata_max_bytes 만 작게 잡고 max_file_bytes 는 충분히 크게 둔다.
+        long_text = "x" * 5000
+        (tmp_path / "README.md").write_text(long_text, encoding="utf-8")
+        snap = scan_project(tmp_path, metadata_max_bytes=100)
+        readme = next(m for m in snap.metadata_files if m.path == "README.md")
+        assert readme.truncated is True
+        assert len(readme.content) <= 100
+
+
+class TestSnapshotShape:
+    def test_snapshot_has_root_and_defaults(self, tmp_path: Path) -> None:
+        snap = scan_project(tmp_path)
+        assert isinstance(snap, ProjectSnapshot)
+        assert snap.root == str(tmp_path.resolve())
+        assert snap.max_depth == DEFAULT_MAX_DEPTH
+        assert snap.max_file_bytes == DEFAULT_MAX_FILE_BYTES
+        assert snap.tree.path == "."
+        assert snap.tree.depth == 0

--- a/tests/init/test_scanner.py
+++ b/tests/init/test_scanner.py
@@ -58,7 +58,10 @@ def _find_file(node: DirectoryEntry, rel_path: str) -> "FileEntry | None":
 
 class TestScannerDepthLimit:
     def test_excludes_files_beyond_max_depth(self, tmp_path: Path) -> None:
-        # 5단계 깊이 트리: tmp_path/d1/d2/d3/d4/d5/leaf.txt (루트=0, leaf=6)
+        # 트리: tmp_path(=루트, depth=0)/d1/d2/d3/d4/d5/d6/leaf.txt
+        # ``range(1, 7)`` 으로 d1..d6 까지 6단계가 만들어진다(d6.depth=6).
+        # leaf.txt 는 d6 안에 있으므로 depth=7. (이전 주석에 "leaf=6" 으로 적혀
+        # 있었으나 잘못된 계산이었다 — 정확히는 depth=7 이다.)
         deep = tmp_path
         for i in range(1, 7):
             deep = deep / f"d{i}"
@@ -66,7 +69,8 @@ class TestScannerDepthLimit:
         leaf = deep / "leaf.txt"
         leaf.write_text("hello", encoding="utf-8")
 
-        # max_depth=4 이면 d4 까지 노출, d5 이후는 truncated 로 표시되거나 미포함.
+        # max_depth=4 이면 d4(depth=4) 까지 노출, d5(depth=5) 는 truncated sentinel
+        # 로만 등장하고 d6/leaf.txt(depth>=6) 은 트리에 일절 포함되지 않는다.
         snap = scan_project(tmp_path, max_depth=4)
         all_paths = _all_paths(snap.tree)
         # leaf 의 전체 경로는 절대 포함되어선 안 된다(깊이 6이라 4단계 초과).
@@ -130,6 +134,40 @@ class TestScannerIgnorePatterns:
         snap = scan_project(tmp_path)
         for meta in snap.metadata_files:
             assert ".env" not in meta.path
+
+    def test_skips_extended_secret_patterns(self, tmp_path: Path) -> None:
+        """리뷰 라운드 2: ``*.key`` / ``*.pfx`` / ``id_dsa`` / ``id_ed25519`` /
+        ``credentials*`` / ``secrets.*`` / ``*.netrc`` / ``.npmrc`` / ``.pypirc``
+        / ``id_rsa_legacy`` (와일드카드 변형) 까지 제외되는지 보강 검증.
+        """
+        names_to_create = [
+            "client.key",
+            "store.pfx",
+            "android.jks",
+            "java.keystore",
+            "id_dsa",
+            "id_ecdsa",
+            "id_ed25519",
+            "id_rsa_legacy",  # 와일드카드 변형: id_rsa* 로 잡혀야 함
+            "credentials",
+            "credentials.json",
+            "secrets.yaml",
+            "secret.toml",
+            ".npmrc",
+            ".pypirc",
+            ".netrc",
+            "my.netrc",
+        ]
+        for name in names_to_create:
+            (tmp_path / name).write_text("S", encoding="utf-8")
+        # 정상 파일도 하나 두어 스캐너 자체는 동작해야 함을 확인.
+        (tmp_path / "main.py").write_text("print('hi')", encoding="utf-8")
+
+        snap = scan_project(tmp_path)
+        present = {p.split("/")[-1] for p in _all_paths(snap.tree)}
+        for forbidden in names_to_create:
+            assert forbidden not in present, f"{forbidden} 이(가) 노출됨"
+        assert "main.py" in present
 
 
 class TestScannerOversize:


### PR DESCRIPTION
Closes #9

## 변경 요약
`/init` 슬래시 명령을 추가해 현재 작업 디렉토리를 정적 분석한 결과를 `SICODE.md`로 저장합니다. 다음 세션에서 LLM이 프로젝트 맥락을 빠르게 재사용할 수 있도록 디렉토리 트리, 프로젝트 메타데이터 본문, 스킵된 파일 목록, 선택적 LLM 요약을 마크다운 한 파일에 모읍니다. 기존 슬래시 명령 레지스트리의 OCP 흐름을 그대로 따르며 `sicode/repl.py`는 수정하지 않았습니다.

## 주요 변경
- `sicode/init/scanner.py`: `pathlib` 기반 스캐너. 4단계 깊이 제한, `.git/__pycache__/.env/*.pem/id_rsa*` 등 보안·노이즈 패턴 무시, NULL 바이트 휴리스틱으로 바이너리 판별, 1 MiB 초과 파일은 메타데이터만 수집, `pyproject.toml/package.json/README.md/Makefile/*.toml/requirements*.txt` 등 메타데이터 파일 본문 수집.
- `sicode/init/renderer.py`: `ProjectSnapshot` → 마크다운 변환. 디렉토리 트리·메타데이터 코드 블록(본문에 백틱이 있으면 펜스 자동 확장)·스킵 파일 목록·선택적 LLM 요약 섹션을 포함.
- `sicode/init/command.py`: `InitCommand`. scanner/renderer/writer/summarizer/cwd_fn 모두 DI 가능. 기존 `SICODE.md`가 있으면 `SICODE.md.bak`로 백업하고 백업 경로와 저장 절대 경로를 모두 출력. summarizer 예외는 흡수돼 Ollama 부재에도 명령이 정상 완료.
- `sicode/commands/__init__.py`: `register_default_commands()`에서 `InitCommand`를 지연 임포트해 등록. 빈 레지스트리(`len()==0`)가 falsy로 평가돼 잘못 라우팅되던 잠재 버그를 `is None` 체크로 함께 수정.
- `tests/init/`: scanner / renderer / command / REPL 통합을 다루는 32개 신규 테스트.

## 수용 기준 라이브 검증
- `/init` 입력으로 `sicode/repl.py` 미수정 상태에서 명령 실행 OK (`tests/init/test_command.py::test_repl_run_with_slash_init_does_not_call_mode_handle`).
- 4단계 초과 깊이 미포함 (`test_excludes_files_beyond_max_depth`).
- `.git/__pycache__/.env/*.pem` 본문 미포함 (`test_skips_dot_git_and_pycache`, `test_skips_secrets_env_and_pem_and_id_rsa`).
- 1 MiB 초과 파일은 본문 없이 메타데이터만 (`test_oversize_file_records_metadata_only` + 렌더러 `test_skipped_section_lists_oversize_and_binary`).
- 기존 `SICODE.md`가 있으면 `SICODE.md.bak` 생성 및 REPL 출력 (`test_existing_file_backup_flow`, `test_creates_backup_when_existing`).
- Ollama 부재(예외) 시에도 정적 분석 결과만으로 정상 완료 (`test_summarizer_exception_is_swallowed`).
- 저장 후 절대 경로 출력 (`test_end_to_end_writes_real_file`).
- scanner/renderer/InitCommand 단위 테스트 모두 통과.
- 기존 107개 테스트 회귀 없음.

## 테스트 실행 결과
```
$ python -m pytest
139 passed in 0.12s
```

## Test plan
- [x] `python -m pytest` (139 passed, 0.12s)
- [x] 임시 디렉토리에서 `/init` 직접 실행 → `SICODE.md` 생성, 백업 동작 수기 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)