### PR TITLE
docs: 회의록·일지 (#9, #11, #14)

### DIFF
--- a/docs/daily/2026-05-02.md
+++ b/docs/daily/2026-05-02.md
@@ -1,0 +1,29 @@
+# 2026-05-02 작업일지
+
+> 자동 생성됨. 서기 에이전트가 새 작업 완료 시마다 갱신.
+
+## 요약
+
+- 총 작업: **2건**
+- 승인 완료: 2건
+- 수동검토 필요: 0건
+
+## 작업 목록
+
+### #9 /init 슬래시 명령 구현: 현재 디렉토리 컨텍스트를 마크다운으로 저장
+
+- 상태: **✓ 승인 (머지 완료)**
+- 이슈: https://github.com/kim-taehan/si-code/issues/9
+- PR: https://github.com/kim-taehan/si-code/pull/12
+- 브랜치: `agent/issue-9`
+- 리뷰 라운드: 3회
+- 상세 회의록: [issue-9-init 슬래시 명령.md](../runs/2026-05-02/issue-9-init%20슬래시%20명령.md)
+
+### #11 Ollama /api/chat 기반 멀티턴 대화 지원
+
+- 상태: **✓ 승인 (머지 완료)**
+- 이슈: https://github.com/kim-taehan/si-code/issues/11
+- PR: https://github.com/kim-taehan/si-code/pull/13
+- 브랜치: `agent/issue-11`
+- 리뷰 라운드: 1회
+- 상세 회의록: [issue-11-멀티턴 채팅.md](../runs/2026-05-02/issue-11-멀티턴%20채팅.md)

--- a/docs/daily/2026-05-03.md
+++ b/docs/daily/2026-05-03.md
@@ -1,0 +1,20 @@
+# 2026-05-03 작업일지
+
+> 자동 생성됨. 서기 에이전트가 새 작업 완료 시마다 갱신.
+
+## 요약
+
+- 총 작업: **1건**
+- 승인 완료: 1건
+- 수동검토 필요: 0건
+
+## 작업 목록
+
+### #14 JSON 모델 레지스트리 + /model//models 슬래시 명령으로 모델 전환
+
+- 상태: **✓ 승인 (머지 완료)**
+- 이슈: https://github.com/kim-taehan/si-code/issues/14
+- PR: https://github.com/kim-taehan/si-code/pull/15
+- 브랜치: `agent/issue-14`
+- 리뷰 라운드: 1회
+- 상세 회의록: [issue-14-모델 레지스트리.md](../runs/2026-05-03/issue-14-모델%20레지스트리.md)

--- a/docs/runs/2026-05-02/issue-11-멀티턴 채팅.md
+++ b/docs/runs/2026-05-02/issue-11-멀티턴 채팅.md
@@ -1,0 +1,49 @@
+---
+issue_num: 11
+issue_url: https://github.com/kim-taehan/si-code/issues/11
+pr_url: https://github.com/kim-taehan/si-code/pull/13
+branch: agent/issue-11
+title: "Ollama /api/chat 기반 멀티턴 대화 지원"
+status: approved
+rounds: 1
+date: 2026-05-02
+created_at: 2026-05-02T00:00:00+09:00
+---
+
+# 실행 기록: Ollama /api/chat 기반 멀티턴 대화 지원
+
+## TL;DR
+
+Ollama의 `/api/chat` 엔드포인트를 활용한 멀티턴 대화 기능을 구현했다. `Conversation` 클래스로 히스토리를 관리하고 `OllamaChatClient`로 HTTP 통신을 처리하며, `/clear`/`/system` 슬래시 명령도 추가했다. 기존 28개 OllamaMode 테스트 회귀 없이 신규 68개 테스트를 포함한 215개 전체 pass하며 라운드 1에서 즉시 승인·머지되었다.
+
+## 사용자 요청
+
+Ollama 백엔드에서 이전 대화 맥락을 유지하는 멀티턴 채팅을 지원해 달라는 요청. **핵심 의도**: 단일 턴 응답에서 벗어나 대화 흐름을 이어가는 REPL 경험 제공.
+
+## 분석가 결과 요약
+
+히스토리 관리(`Conversation`), HTTP 클라이언트(`OllamaChatClient`), REPL 무수정 원칙(OCP), 슬래시 명령 확장(`/clear`/`/system`), 환경변수로 히스토리 길이 조정이 수용기준으로 정의되었다.
+
+## 개발자 작업 (라운드별)
+
+### 라운드 1
+
+- 변경된 파일: `Conversation` 클래스(히스토리 + max-turn drop), `OllamaChatClient`(표준 라이브러리 `/api/chat` HTTP) 신규 추가; `OllamaMode` polymorphic 분기 수정; `main.py` 기본 클라이언트 교체; 슬래시 명령 `/clear`/`/system` 추가; `ReplContext`에 `mode`/`argument` 필드 추가
+- 핵심 로직: `hasattr(client, "chat")`으로 single/multi 분기 → `OllamaMode` 기존 단위 테스트 회귀 없음; `SICODE_OLLAMA_MAX_TURNS` 환경변수로 히스토리 길이 조정(DIP); REPL 코드 무수정(OCP)
+- 테스트: 신규 68개 테스트, 전체 215 pass(회귀 0)
+
+## 리뷰 히스토리
+
+### 라운드 1
+
+- 판정: [APPROVED]
+- 핵심 지적: 모든 수용기준 충족, SOLID 위반 없음, Critical 없음.
+
+## 최종 상태
+
+- 승인: 모든 수용기준 충족, 기존 OllamaMode 회귀 없음, 215개 테스트 pass, 머지 커밋 5ed995c
+
+## 후속 조치
+
+- 알려진 한계/가정: max-turn drop 정책은 오래된 턴을 선입선출로 제거하는 단순 방식
+- 추후 작업: (정보 없음)

--- a/docs/runs/2026-05-02/issue-9-init 슬래시 명령.md
+++ b/docs/runs/2026-05-02/issue-9-init 슬래시 명령.md
@@ -1,0 +1,80 @@
+---
+issue_num: 9
+issue_url: https://github.com/kim-taehan/si-code/issues/9
+pr_url: https://github.com/kim-taehan/si-code/pull/12
+branch: agent/issue-9
+title: "/init 슬래시 명령 구현: 현재 디렉토리 컨텍스트를 마크다운으로 저장"
+status: approved
+rounds: 3
+date: 2026-05-02
+created_at: 2026-05-02T00:00:00+09:00
+---
+
+# 실행 기록: /init 슬래시 명령 구현: 현재 디렉토리 컨텍스트를 마크다운으로 저장
+
+## TL;DR
+
+현재 디렉토리의 파일 구조와 코드 컨텍스트를 마크다운 스냅샷(`SICODE.md`)으로 저장하는 `/init` 슬래시 명령을 구현했다. 라운드 1~2에서 symlink follow에 의한 임의 파일 유출/덮어쓰기 보안 결함이 발견되었고, 라운드 3에서 `Path.absolute()`로 leaf symlink를 보존하는 방식으로 완전히 차단하여 PoC 검증까지 통과했다. 최종 147개 테스트 모두 pass하며 라운드 3에서 승인·머지 완료되었다.
+
+## 사용자 요청
+
+현재 작업 디렉토리의 파일 트리와 코드 내용을 스캔해 `SICODE.md` 파일로 저장하는 `/init` 슬래시 명령을 구현해 달라는 요청. **핵심 의도**: AI 에이전트가 프로젝트 컨텍스트를 빠르게 파악할 수 있도록 디렉토리 스냅샷을 마크다운으로 자동 생성.
+
+## 분석가 결과 요약
+
+scanner/renderer/command 세 레이어로 분리하는 아키텍처를 요구사항으로 정의했다. 출력 경로 안전성(symlink, 이진 파일, 민감 파일 제외), 백업(`SICODE.md.bak`) 처리, 무시 패턴 목록이 수용기준(AC)으로 명세되었다.
+
+## 개발자 작업 (라운드별)
+
+### 라운드 1
+
+- 변경된 파일: scanner, renderer, command 모듈 신규 추가, 단위 테스트 파일 추가
+- 핵심 로직: `/init` 명령 실행 시 디렉토리를 스캔해 마크다운으로 렌더링 후 `SICODE.md`에 저장; 기존 파일은 `.bak`으로 백업
+- 테스트: 32개 테스트 추가, 전체 139 pass
+
+### 라운드 2
+
+- 보안 수정: `UnsafeOutputPathError` 예외 도입, `os.replace` + `os.open(O_NOFOLLOW|O_EXCL)`로 symlink follow 차단
+- 무시 패턴 보강: `*.pfx`, `credentials*`, `*.netrc`, `id_rsa*` 와일드카드 등 민감 파일 패턴 추가
+- "순환 참조" 주석을 실제 재현 가능한 사례로 정정
+- 신규 회귀 테스트 5건 추가, 전체 144 pass
+- 리뷰어 지적으로 추가 결함 발견: `InitCommand.execute`에서 `Path.resolve()`가 symlink를 사전에 풀어 보안 검사 우회 — 라운드 1 결함 통합 경로에서 그대로 재현(PoC 확인)
+
+### 라운드 3
+
+- 핵심 수정: `Path.resolve()` → `Path.absolute()`로 교체해 leaf symlink 보존, `_validate_output_path` 헬퍼 추출(SRP/OCP)
+- docstring에 호출자 계약/NFS/lstat 보수적 거부 명시
+- "순환 참조" 정정 주석을 정직한 설명으로 재작성
+- scanner의 의미 없는 `*.aws` 패턴 제거
+- 통합 회귀 테스트 3건(`TestInitCommandSymlinkSafetyIntegration`) 추가, 전체 147 pass
+- PoC 검증: 수정 전 외부 파일 덮어쓰기 재현 → 수정 후 거부 + 외부 파일 무변동 확인
+
+## 리뷰 히스토리
+
+### 라운드 1
+
+- 판정: [CHANGES_REQUESTED]
+- 핵심 지적:
+  1. `write_snapshot_file`이 symlink follow로 임의 파일이 `SICODE.md.bak`으로 유출/덮어쓰기될 수 있는 보안 결함
+  2. 보안 수정에 대한 회귀 테스트 누락
+  3. "순환 참조" 주석 정정 필요
+
+### 라운드 2
+
+- 판정: [CHANGES_REQUESTED]
+- 핵심 지적:
+  1. `InitCommand.execute`가 `Path.resolve()`로 symlink를 사전에 풀어 보안 검사 우회 — 통합 경로에서 라운드 1 결함 그대로 재현(PoC 확인됨)
+
+### 라운드 3
+
+- 판정: [APPROVED]
+- 핵심 지적: 라운드 2 Critical 통합 경로에서 차단 확인, 보안/SOLID/회귀 모두 양호. Critical 없음.
+
+## 최종 상태
+
+- 승인: 세 라운드에 걸친 symlink 보안 결함 완전 차단(PoC 검증 포함), 147개 테스트 pass, 머지 커밋 965a0e3
+
+## 후속 조치
+
+- 알려진 한계/가정: NFS 환경에서 lstat 실패 시 보수적 거부 정책 적용(docstring에 명시)
+- 추후 작업: `*.aws` 외 불필요한 무시 패턴 정기 검토 권장

--- a/docs/runs/2026-05-03/issue-14-모델 레지스트리.md
+++ b/docs/runs/2026-05-03/issue-14-모델 레지스트리.md
@@ -1,0 +1,52 @@
+---
+issue_num: 14
+issue_url: https://github.com/kim-taehan/si-code/issues/14
+pr_url: https://github.com/kim-taehan/si-code/pull/15
+branch: agent/issue-14
+title: "JSON 모델 레지스트리 + /model//models 슬래시 명령으로 모델 전환 (Tab 키 처리는 후속 분리)"
+status: approved
+rounds: 1
+date: 2026-05-03
+created_at: 2026-05-03T00:00:00+09:00
+---
+
+# 실행 기록: JSON 모델 레지스트리 + /model//models 슬래시 명령으로 모델 전환
+
+## TL;DR
+
+`~/.config/sicode/models.json`에 모델 목록을 선언하고 `/model`·`/models` 슬래시 명령으로 런타임 모델 전환을 구현했다. 모델 변경 시 `Conversation` 인스턴스를 재사용해 히스토리를 보존하며, `OllamaMode`가 `client_factory`에 의존(DIP)하는 설계로 REPL 무수정(OCP)을 유지했다. 신규 82개 테스트를 포함한 297개 전체 pass하며 라운드 1에서 즉시 승인·머지되었다.
+
+## 사용자 요청
+
+JSON 파일로 모델 목록을 관리하고 REPL 실행 중 명령어로 모델을 전환할 수 있게 해 달라는 요청. **핵심 의도**: 코드 수정 없이 모델을 선언적으로 등록하고 대화 히스토리를 유지하면서 모델 전환.
+
+## 분석가 결과 요약
+
+JSON 레지스트리 파일 구조, `/model <이름>` 전환 명령, `/models` 목록 조회 명령, 전환 시 히스토리 보존, 기존 단위 테스트 monkeypatch 호환성이 수용기준으로 정의되었다. Tab 키 자동완성은 후속 이슈로 분리되었다.
+
+## 개발자 작업 (라운드별)
+
+### 라운드 1
+
+- 변경된 파일: `~/.config/sicode/models.json` 모델 목록 파일, `/model`·`/models` 슬래시 명령 모듈, `OllamaMode` client_factory 의존성 주입 수정, `_select_mode_with_registry` 분리, `main.py` 진입점 업데이트
+- 핵심 로직: 모델 변경 시 `OllamaMode._client`를 새 `OllamaChatClient`로 교체하되 `Conversation` 인스턴스 재사용 → 히스토리 보존; `OllamaMode`가 `client_factory: Callable[[str], OllamaChatClient]`에 의존(DIP); `_select_mode_with_registry` 분리로 기존 단위 테스트 monkeypatch 호환 유지
+- 테스트: 신규 82개 테스트, 전체 297 pass(215+82, 회귀 0)
+
+## 리뷰 히스토리
+
+### 라운드 1
+
+- 판정: [APPROVED]
+- 핵심 지적: 9개 수용기준 모두 충족, Critical 없음. Suggestion 8건(후속 cleanup 후보):
+  1. `_select_mode is _ORIGINAL_SELECT_MODE` 영리한 분기 방식
+  2. `models.py`의 `model.py` 비공개 함수 import
+  3. 환경변수 빈 문자열 처리 등
+
+## 최종 상태
+
+- 승인: 9개 수용기준 전부 충족, 297개 테스트 pass(회귀 0), 머지 커밋 b471e86
+
+## 후속 조치
+
+- 알려진 한계/가정: Tab 키 자동완성은 이번 범위에서 제외(후속 이슈로 분리 예정)
+- 추후 작업: 리뷰어 Suggestion 8건(`_select_mode` 분기 정리, `model.py` 비공개 함수 import 정리, 환경변수 빈 문자열 처리) cleanup


### PR DESCRIPTION
## Summary

- 이슈 #9 (`/init` 슬래시 명령, 3라운드, PR #12): symlink 보안 결함을 3라운드에 걸쳐 완전 수정한 회의록 추가
- 이슈 #11 (Ollama 멀티턴 채팅, 1라운드, PR #13): `/api/chat` 기반 멀티턴 대화 구현 회의록 추가
- 이슈 #14 (JSON 모델 레지스트리, 1라운드, PR #15): `/model`·`/models` 슬래시 명령 구현 회의록 추가
- `docs/daily/2026-05-02.md`, `docs/daily/2026-05-03.md` 일일 작업일지 추가

## Test plan

- [ ] `docs/runs/2026-05-02/` 두 파일 front-matter 및 본문 확인
- [ ] `docs/runs/2026-05-03/` 파일 front-matter 및 본문 확인
- [ ] `docs/daily/2026-05-02.md`, `docs/daily/2026-05-03.md` 링크 URL 인코딩 확인
- [ ] 기존 `docs/daily/2026-04-30.md`, `docs/daily/2026-05-01.md` 형식과 일관성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)