### PR TITLE
feat: add !cmd shell prefix to REPL (#18)

### DIFF
--- a/sicode/bang/__init__.py
+++ b/sicode/bang/__init__.py
@@ -1,0 +1,47 @@
+"""``!cmd`` prefix 셸 실행 패키지.
+
+REPL 입력이 ``!`` 로 시작하면 슬래시 명령/모드 전달과 무관하게 본 모듈의
+:func:`handle_bang_input` 으로 분기된다. 본 패키지는 다음 책임만 갖는다 (SRP):
+
+- ``!`` 뒤 문자열을 추출하고, 빈 입력을 안내 문구로 막는다.
+- :func:`run_shell` 로 서브프로세스를 동기 실행하고 stdout/stderr/exit code 를
+  REPL 출력 형식에 맞춰 한 줄씩 모아 돌려준다.
+- 멀티턴 히스토리 (``mode.handle``) 와 완전히 격리한다.
+
+설계 메모:
+    - SRP: 셸 실행 로직(:mod:`sicode.bang.executor`) 과 REPL 표시 로직
+      (:func:`format_bang_output` / :func:`handle_bang_input`) 을 분리한다.
+    - DIP: 테스트는 ``runner`` 콜러블을 :func:`handle_bang_input` 에 주입해
+      서브프로세스 호출 없이 결과 객체를 합성한다.
+    - OCP: ``!`` 외 prefix 를 추가할 가능성은 본 이슈 범위 외 — 인터페이스
+      추상화 (``PrefixHandler`` 등) 는 하지 않고 단일 진입점만 제공한다.
+"""
+
+from __future__ import annotations
+
+from sicode.bang.executor import (
+    BANG_PREFIX,
+    DEFAULT_TIMEOUT_SECONDS,
+    TIMEOUT_ENV_VAR,
+    BangResult,
+    BangTimeout,
+    format_bang_output,
+    handle_bang_input,
+    is_bang_input,
+    resolve_timeout_seconds,
+    run_shell,
+)
+
+
+__all__ = [
+    "BANG_PREFIX",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "TIMEOUT_ENV_VAR",
+    "BangResult",
+    "BangTimeout",
+    "format_bang_output",
+    "handle_bang_input",
+    "is_bang_input",
+    "resolve_timeout_seconds",
+    "run_shell",
+]

--- a/sicode/bang/executor.py
+++ b/sicode/bang/executor.py
@@ -1,0 +1,265 @@
+"""``!cmd`` prefix 셸 실행기.
+
+REPL 의 ``!`` 분기에서 호출되는 작은 함수들의 모음. 책임 경계:
+
+- :func:`is_bang_input`: 입력이 bang 분기 대상인지 단순 판정 (왼쪽 공백 trim 후
+  ``!`` 시작 여부). REPL 에서 슬래시 명령 분기와 동등한 위치에 배치한다.
+- :func:`resolve_timeout_seconds`: 환경 변수 ``SICODE_BANG_TIMEOUT`` 을 정수로
+  해석하고, 잘못된 값/0 이하 값은 기본값 60 으로 떨어진다.
+- :func:`run_shell`: ``subprocess.run`` 래퍼. ``shell=True`` / ``stdin=DEVNULL``
+  / ``capture_output`` / ``text=True`` / ``cwd=Path.cwd()`` 를 강제한다.
+- :func:`format_bang_output`: 결과 객체를 REPL stdout/stderr 표시 규약에 따라
+  단일 문자열(빈 줄 포함 가능) 로 변환한다.
+- :func:`handle_bang_input`: 위 함수들을 묶는 진입점. ``runner`` 를 주입할 수
+  있어 테스트가 :mod:`subprocess` mock 없이도 가능하다 (DIP).
+
+설계 메모:
+    - SRP: 한 함수 = 한 책임. ``run_shell`` 은 IO 만, ``format_bang_output`` 은
+      문자열 가공만 담당한다.
+    - DIP: 테스트가 ``runner`` 를 주입해 서브프로세스 실제 실행을 우회한다.
+    - 보안: 본 모듈은 명령 필터링/허용 목록을 도입하지 않는다 — 사용자는
+      자신의 셸과 동일한 권한으로 명령을 실행한다는 것을 환영 메시지/``/help``
+      가 사전 안내한다.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+
+#: REPL 입력의 bang 분기 prefix.
+BANG_PREFIX: str = "!"
+
+#: ``SICODE_BANG_TIMEOUT`` 미설정/오류 시 적용되는 기본 타임아웃(초).
+DEFAULT_TIMEOUT_SECONDS: int = 60
+
+#: 사용자 재정의용 환경 변수 이름.
+TIMEOUT_ENV_VAR: str = "SICODE_BANG_TIMEOUT"
+
+
+@dataclass(frozen=True)
+class BangResult:
+    """:func:`run_shell` 반환 객체.
+
+    Attributes:
+        stdout: 명령의 표준 출력(개행 포함될 수 있음).
+        stderr: 명령의 표준 에러.
+        returncode: 종료 코드.
+        timed_out: ``False`` 고정. 타임아웃은 :class:`BangTimeout` 으로 분리한다.
+    """
+
+    stdout: str
+    stderr: str
+    returncode: int
+    timed_out: bool = False
+
+
+@dataclass(frozen=True)
+class BangTimeout:
+    """타임아웃이 발생했을 때 :func:`run_shell` 이 반환하는 표시용 객체.
+
+    REPL 표시 단계에서 :class:`BangResult` 와 분기 처리하기 위해 별도 타입으로
+    분리했다(LSP 측면에서 같은 인터페이스를 강요하지 않기 위함).
+    """
+
+    timeout: int
+
+
+#: ``run_shell`` 시그니처와 호환되는 콜러블 (테스트 주입용).
+ShellRunner = Callable[..., "BangResult | BangTimeout"]
+
+
+# ---------------------------------------------------------------------------- helpers
+
+
+def is_bang_input(user_input: str) -> bool:
+    """입력이 bang 분기 대상인지 판정한다.
+
+    슬래시 분기와 동일하게 왼쪽 공백을 무시한다. 본 함수는 입력 본문에 어떤
+    유효성 검사도 하지 않는다 — 비어 있는 ``!`` 도 ``True`` 를 반환하고,
+    호출자(:func:`handle_bang_input`) 가 안내 문구를 출력한다.
+    """
+    return user_input.lstrip().startswith(BANG_PREFIX)
+
+
+def resolve_timeout_seconds(
+    env: Optional["os._Environ[str]"] = None,
+    *,
+    default: int = DEFAULT_TIMEOUT_SECONDS,
+) -> int:
+    """``SICODE_BANG_TIMEOUT`` 을 정수로 해석한다.
+
+    Args:
+        env: 환경 변수 매핑. ``None`` 이면 :data:`os.environ` 사용.
+        default: 미설정/파싱 실패/비양수 시 적용할 기본값.
+
+    Returns:
+        양의 정수. 잘못된 값은 ``default`` 로 떨어진다.
+    """
+    source = os.environ if env is None else env
+    raw = source.get(TIMEOUT_ENV_VAR)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        return default
+    if value <= 0:
+        return default
+    return value
+
+
+def _strip_bang_prefix(user_input: str) -> str:
+    """입력에서 ``!`` 와 그 앞의 공백을 제거한 명령 본문을 돌려준다.
+
+    호출자는 이 결과를 ``str.strip()`` 으로 후처리해 빈 명령 여부를 판정한다.
+    """
+    after_lstrip = user_input.lstrip()
+    if not after_lstrip.startswith(BANG_PREFIX):
+        return after_lstrip
+    return after_lstrip[len(BANG_PREFIX):]
+
+
+# ---------------------------------------------------------------------------- runner
+
+
+def run_shell(
+    cmd: str,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+) -> "BangResult | BangTimeout":
+    """주어진 셸 명령을 실행하고 결과를 돌려준다.
+
+    ``shell=True`` 로 파이프/리다이렉션/glob 을 그대로 지원하며, ``stdin`` 은
+    :data:`subprocess.DEVNULL` 로 봉쇄해 인터랙티브 입력을 막는다.
+
+    Args:
+        cmd: ``!`` 를 제거한 명령 문자열. 빈 문자열은 호출자가 사전 차단한다.
+        timeout: 타임아웃 초. ``subprocess.TimeoutExpired`` 발생 시
+            :class:`BangTimeout` 객체를 돌려준다.
+
+    Returns:
+        성공/실패와 관계 없이 정상 완료시 :class:`BangResult`,
+        타임아웃 시 :class:`BangTimeout`.
+    """
+    try:
+        completed = subprocess.run(  # noqa: S602 - 의도적 shell=True (이슈 #18 합의)
+            cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            timeout=timeout,
+            cwd=str(Path.cwd()),
+        )
+    except subprocess.TimeoutExpired:
+        return BangTimeout(timeout=timeout)
+    return BangResult(
+        stdout=completed.stdout or "",
+        stderr=completed.stderr or "",
+        returncode=int(completed.returncode),
+    )
+
+
+# ---------------------------------------------------------------------------- formatter
+
+
+def _prefix_lines(text: str, prefix: str) -> str:
+    """``text`` 의 각 라인에 ``prefix`` 를 붙인다.
+
+    빈 문자열은 빈 문자열 그대로 돌려준다. 마지막 개행은 보존하지 않는다 — 호출
+    측에서 join 시 제어한다.
+    """
+    if text == "":
+        return ""
+    # 마지막 개행이 있으면 splitlines 가 무시하므로 별도로 보존
+    trailing_nl = text.endswith("\n")
+    body = "\n".join(prefix + line for line in text.splitlines())
+    return body + ("\n" if trailing_nl else "")
+
+
+def format_bang_output(result: "BangResult | BangTimeout") -> str:
+    """실행 결과를 REPL output_fn 한 번 호출 분량의 문자열로 변환한다.
+
+    표시 규약 (이슈 #18):
+        - stdout 은 그대로 출력한다.
+        - stderr 는 각 줄 앞에 ``[stderr] `` 를 붙인다.
+        - returncode 가 0 이 아니면 ``[exit code: N]`` 한 줄을 마지막에 추가한다.
+        - 모두 비어 있으면 빈 문자열을 돌려준다 (REPL 측에서 출력 생략).
+        - 타임아웃은 ``[bang] 명령이 타임아웃되었습니다 (Ns). REPL을 계속합니다.``
+          한 줄로 변환된다.
+
+    Args:
+        result: :func:`run_shell` 반환 객체.
+
+    Returns:
+        합성된 출력 문자열. 줄 사이 구분은 ``\\n`` 으로 합친다.
+    """
+    if isinstance(result, BangTimeout):
+        return (
+            f"[bang] 명령이 타임아웃되었습니다 ({result.timeout}s). "
+            "REPL을 계속합니다."
+        )
+
+    parts = []
+    stdout = result.stdout.rstrip("\n")
+    if stdout != "":
+        parts.append(stdout)
+    stderr_formatted = _prefix_lines(result.stderr.rstrip("\n"), "[stderr] ")
+    if stderr_formatted != "":
+        parts.append(stderr_formatted)
+    if result.returncode != 0:
+        parts.append(f"[exit code: {result.returncode}]")
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------- entrypoint
+
+
+def handle_bang_input(
+    user_input: str,
+    *,
+    runner: Optional[ShellRunner] = None,
+    timeout: Optional[int] = None,
+) -> str:
+    """REPL 의 ``!`` 분기 진입점.
+
+    Args:
+        user_input: 사용자가 입력한 한 줄 (앞뒤 공백, ``!`` 포함).
+        runner: ``run_shell`` 호환 콜러블. ``None`` 이면 :func:`run_shell` 사용.
+            테스트에서 서브프로세스 실제 실행을 우회하기 위해 주입한다 (DIP).
+        timeout: 사용할 타임아웃(초). ``None`` 이면 :func:`resolve_timeout_seconds`
+            로 환경 변수에서 해석한다. 0 이하/None-경계 동작은 그 함수가 흡수한다.
+
+    Returns:
+        REPL ``output_fn`` 한 번 호출에 적합한 문자열.
+        ``!`` 뒤가 비어 있으면 사용 안내 문자열을 돌려준다.
+    """
+    body = _strip_bang_prefix(user_input).strip()
+    if body == "":
+        return "[bang] 실행할 명령을 입력하세요. 예시: !ls"
+
+    actual_runner = runner or run_shell
+    actual_timeout = (
+        timeout if timeout is not None and timeout > 0 else resolve_timeout_seconds()
+    )
+    result = actual_runner(body, actual_timeout)
+    return format_bang_output(result)
+
+
+__all__ = [
+    "BANG_PREFIX",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "TIMEOUT_ENV_VAR",
+    "BangResult",
+    "BangTimeout",
+    "ShellRunner",
+    "format_bang_output",
+    "handle_bang_input",
+    "is_bang_input",
+    "resolve_timeout_seconds",
+    "run_shell",
+]

--- a/sicode/commands/help.py
+++ b/sicode/commands/help.py
@@ -1,6 +1,7 @@
 """``/help`` 슬래시 명령.
 
 등록된 모든 슬래시 명령(이름·별칭·설명)을 이름 알파벳 오름차순으로 출력한다.
+``!cmd`` (셸 prefix) 사용법도 함께 안내한다.
 """
 
 from __future__ import annotations
@@ -11,6 +12,19 @@ from sicode.commands.base import CommandResult, ReplContext, SlashCommand
 
 if TYPE_CHECKING:  # pragma: no cover - 타입 힌트 전용
     from sicode.commands.registry import SlashCommandRegistry
+
+
+#: ``/help`` 출력 말미에 추가되는 ``!cmd`` 안내 블록.
+#:
+#: 슬래시 명령 디스패처와 bang 분기는 서로 별개의 입력 prefix 이지만, ``/help``
+#: 가 사용자가 가장 먼저 찾는 도움말이므로 함께 안내한다(이슈 #18).
+BANG_HELP_LINES: "tuple[str, ...]" = (
+    "",
+    "Shell prefix:",
+    "  !<cmd> - 셸에서 명령을 직접 실행 (예: !ls, !git status, !cat file.txt).",
+    "  주의: 시스템에 직접 실행됩니다. 위험한 명령(rm 등)에 유의하세요.",
+    "  타임아웃 기본 60초 — SICODE_BANG_TIMEOUT 환경 변수로 재정의.",
+)
 
 
 class HelpCommand(SlashCommand):
@@ -30,11 +44,15 @@ class HelpCommand(SlashCommand):
     def execute(self, context: ReplContext) -> CommandResult:
         registry = self._registry or context.registry
         if registry is None:
-            return CommandResult.cont(output="No commands registered.")
+            return CommandResult.cont(
+                output="\n".join(("No commands registered.",) + BANG_HELP_LINES)
+            )
 
         commands = registry.commands()
         if not commands:
-            return CommandResult.cont(output="No commands registered.")
+            return CommandResult.cont(
+                output="\n".join(("No commands registered.",) + BANG_HELP_LINES)
+            )
 
         lines = ["Available commands:"]
         for cmd in commands:
@@ -44,7 +62,8 @@ class HelpCommand(SlashCommand):
                 else ""
             )
             lines.append(f"  /{cmd.name}{alias_text} - {cmd.description}")
+        lines.extend(BANG_HELP_LINES)
         return CommandResult.cont(output="\n".join(lines))
 
 
-__all__ = ["HelpCommand"]
+__all__ = ["BANG_HELP_LINES", "HelpCommand"]

--- a/sicode/repl.py
+++ b/sicode/repl.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import Callable, Iterable, Optional
 
 from sicode import __version__
+from sicode.bang import handle_bang_input, is_bang_input
 from sicode.commands.base import CommandAction
 from sicode.commands.registry import (
     SlashCommandRegistry,
@@ -44,6 +45,8 @@ def build_welcome_message(mode: BaseMode, version: str = __version__) -> str:
         "Ollama 서버가 실행 중이어야 합니다 (기본: http://localhost:11434).\n"
         "대화 히스토리가 자동으로 유지됩니다. /clear 로 초기화, "
         "/system <텍스트> 로 시스템 메시지 설정.\n"
+        "!cmd 로 셸 명령을 직접 실행할 수 있습니다 "
+        "(예: !ls, !git status). 주의: 시스템에 직접 실행됩니다.\n"
         "Type 'exit' or 'quit' to leave. Press Ctrl+C / Ctrl+D to abort.\n"
         "Type /help to see available slash commands.\n"
     )
@@ -103,6 +106,13 @@ def run_repl(
             output_fn("")
             output_fn("Interrupted. Goodbye!")
             return 0
+
+        # ``!cmd`` bang 분기는 슬래시 명령과 동급의 우선순위로, mode.handle 보다
+        # 먼저 처리한다. 멀티턴 히스토리에 영향을 주지 않으며 슬래시 명령 디스패처
+        # 도 호출하지 않는다 (이슈 #18).
+        if is_bang_input(user_input):
+            output_fn(handle_bang_input(user_input))
+            continue
 
         # 슬래시 명령은 mode.handle 보다 우선 처리한다 (LLM 미전송).
         if is_slash_command(user_input):

--- a/tests/bang/test_executor.py
+++ b/tests/bang/test_executor.py
@@ -1,0 +1,291 @@
+"""``sicode.bang.executor`` 단위 테스트.
+
+테스트는 :func:`subprocess.run` 을 mock 으로 교체해 외부 프로세스를 실제로 띄우지
+않는다. 또한 :func:`handle_bang_input` 은 ``runner`` 콜러블 주입을 받으므로
+서브프로세스 호출 자체를 우회한 합성 테스트도 함께 둔다 (DIP).
+
+검증 항목 (이슈 #18 수용 기준 매핑):
+    - ``run_shell`` 정상 실행 / 종료 코드 / stdout 캡처
+    - stderr 출력
+    - 비-0 종료 코드의 ``[exit code: N]`` 표시
+    - 타임아웃 메시지
+    - ``shell=True``, ``stdin=DEVNULL``, ``capture_output``, ``text=True``,
+      ``cwd=Path.cwd()`` 인자 전달
+    - 빈 ``!`` 입력 안내
+    - 환경 변수 ``SICODE_BANG_TIMEOUT`` 해석
+    - 출력 형식 합성 (stdout/stderr 동시, 0 종료시 exit 라인 없음)
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from sicode.bang import executor as bang_executor
+from sicode.bang.executor import (
+    DEFAULT_TIMEOUT_SECONDS,
+    TIMEOUT_ENV_VAR,
+    BangResult,
+    BangTimeout,
+    format_bang_output,
+    handle_bang_input,
+    is_bang_input,
+    resolve_timeout_seconds,
+    run_shell,
+)
+
+
+# ---------------------------------------------------------------------------- helpers
+
+
+class _FakeCompleted:
+    """``subprocess.run`` 반환을 흉내내는 단순 객체."""
+
+    def __init__(self, stdout: str = "", stderr: str = "", returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+# ---------------------------------------------------------------------------- is_bang_input
+
+
+class TestIsBangInput:
+    def test_starts_with_bang(self) -> None:
+        assert is_bang_input("!ls") is True
+
+    def test_with_leading_whitespace(self) -> None:
+        assert is_bang_input("   !pwd") is True
+
+    def test_plain_text_is_not_bang(self) -> None:
+        assert is_bang_input("hello") is False
+
+    def test_slash_is_not_bang(self) -> None:
+        assert is_bang_input("/help") is False
+
+    def test_empty_string_is_not_bang(self) -> None:
+        assert is_bang_input("") is False
+
+    def test_bang_alone_is_bang(self) -> None:
+        # 빈 명령 안내 분기는 handle_bang_input 이 처리한다.
+        assert is_bang_input("!") is True
+
+
+# ---------------------------------------------------------------------------- resolve_timeout_seconds
+
+
+class TestResolveTimeoutSeconds:
+    def test_unset_returns_default(self) -> None:
+        env: dict[str, str] = {}
+        assert resolve_timeout_seconds(env) == DEFAULT_TIMEOUT_SECONDS  # type: ignore[arg-type]
+
+    def test_valid_int_string(self) -> None:
+        env = {TIMEOUT_ENV_VAR: "5"}
+        assert resolve_timeout_seconds(env) == 5  # type: ignore[arg-type]
+
+    def test_whitespace_padded_int(self) -> None:
+        env = {TIMEOUT_ENV_VAR: "  10 "}
+        assert resolve_timeout_seconds(env) == 10  # type: ignore[arg-type]
+
+    def test_empty_string_falls_back_to_default(self) -> None:
+        env = {TIMEOUT_ENV_VAR: ""}
+        assert resolve_timeout_seconds(env) == DEFAULT_TIMEOUT_SECONDS  # type: ignore[arg-type]
+
+    def test_invalid_string_falls_back_to_default(self) -> None:
+        env = {TIMEOUT_ENV_VAR: "not-a-number"}
+        assert resolve_timeout_seconds(env) == DEFAULT_TIMEOUT_SECONDS  # type: ignore[arg-type]
+
+    def test_zero_falls_back_to_default(self) -> None:
+        env = {TIMEOUT_ENV_VAR: "0"}
+        assert resolve_timeout_seconds(env) == DEFAULT_TIMEOUT_SECONDS  # type: ignore[arg-type]
+
+    def test_negative_falls_back_to_default(self) -> None:
+        env = {TIMEOUT_ENV_VAR: "-7"}
+        assert resolve_timeout_seconds(env) == DEFAULT_TIMEOUT_SECONDS  # type: ignore[arg-type]
+
+    def test_default_uses_os_environ(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(TIMEOUT_ENV_VAR, "11")
+        assert resolve_timeout_seconds() == 11
+
+    def test_default_argument_override(self) -> None:
+        env: dict[str, str] = {}
+        assert resolve_timeout_seconds(env, default=99) == 99  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------- run_shell
+
+
+class TestRunShell:
+    def test_invokes_subprocess_with_required_kwargs(self) -> None:
+        captured: dict[str, Any] = {}
+
+        def fake_run(cmd: str, **kwargs: Any) -> _FakeCompleted:
+            captured["cmd"] = cmd
+            captured.update(kwargs)
+            return _FakeCompleted(stdout="ok\n", stderr="", returncode=0)
+
+        with mock.patch.object(bang_executor.subprocess, "run", side_effect=fake_run):
+            result = run_shell("echo ok", timeout=42)
+
+        assert isinstance(result, BangResult)
+        assert result.stdout == "ok\n"
+        assert result.stderr == ""
+        assert result.returncode == 0
+        assert captured["cmd"] == "echo ok"
+        assert captured["shell"] is True
+        assert captured["capture_output"] is True
+        assert captured["text"] is True
+        assert captured["stdin"] is subprocess.DEVNULL
+        assert captured["timeout"] == 42
+        # cwd 는 현재 작업 디렉토리 문자열이어야 한다.
+        assert captured["cwd"] == str(Path.cwd())
+
+    def test_returns_bang_timeout_on_timeout_expired(self) -> None:
+        def fake_run(*args: Any, **kwargs: Any) -> _FakeCompleted:
+            raise subprocess.TimeoutExpired(cmd="sleep 99", timeout=1)
+
+        with mock.patch.object(bang_executor.subprocess, "run", side_effect=fake_run):
+            result = run_shell("sleep 99", timeout=1)
+
+        assert isinstance(result, BangTimeout)
+        assert result.timeout == 1
+
+    def test_passes_through_nonzero_returncode(self) -> None:
+        def fake_run(*args: Any, **kwargs: Any) -> _FakeCompleted:
+            return _FakeCompleted(stdout="", stderr="bad\n", returncode=2)
+
+        with mock.patch.object(bang_executor.subprocess, "run", side_effect=fake_run):
+            result = run_shell("false", timeout=10)
+
+        assert isinstance(result, BangResult)
+        assert result.returncode == 2
+        assert result.stderr == "bad\n"
+
+    def test_real_echo_smoke(self) -> None:
+        """실제 ``subprocess.run`` 으로 ``echo`` 한 번. 외부 모델/네트워크 의존 없음."""
+        # macOS/Linux 환경 가정. echo 는 POSIX 표준이고 stdin 미요구.
+        result = run_shell("echo hello-bang", timeout=5)
+        assert isinstance(result, BangResult)
+        assert result.returncode == 0
+        assert "hello-bang" in result.stdout
+
+    def test_real_stdin_devnull(self) -> None:
+        """``stdin=DEVNULL`` 로 봉쇄되었음을 실제 명령으로 검증한다.
+
+        ``cat`` 은 표준 입력 파일이 EOF 면 즉시 종료하고 빈 출력을 반환한다 —
+        만약 stdin 이 봉쇄되지 않았다면 본 테스트가 행(hang) 걸린다.
+        """
+        result = run_shell("cat", timeout=5)
+        assert isinstance(result, BangResult)
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+
+# ---------------------------------------------------------------------------- format_bang_output
+
+
+class TestFormatBangOutput:
+    def test_stdout_only_zero_exit_no_exit_line(self) -> None:
+        out = format_bang_output(BangResult(stdout="hello\n", stderr="", returncode=0))
+        assert out == "hello"
+
+    def test_nonzero_exit_appends_exit_code_line(self) -> None:
+        out = format_bang_output(BangResult(stdout="x\n", stderr="", returncode=3))
+        assert out.endswith("[exit code: 3]")
+        assert out.startswith("x")
+
+    def test_stderr_lines_are_prefixed(self) -> None:
+        out = format_bang_output(
+            BangResult(stdout="", stderr="boom\nbang\n", returncode=1)
+        )
+        # 각 라인 앞에 [stderr] 접두사
+        assert "[stderr] boom" in out
+        assert "[stderr] bang" in out
+        assert "[exit code: 1]" in out
+
+    def test_stdout_and_stderr_both_present(self) -> None:
+        out = format_bang_output(
+            BangResult(stdout="ok\n", stderr="warn\n", returncode=0)
+        )
+        # 0 종료에서는 exit 라인 없음
+        assert "[exit code:" not in out
+        assert "ok" in out
+        assert "[stderr] warn" in out
+
+    def test_empty_result_produces_empty_string(self) -> None:
+        out = format_bang_output(BangResult(stdout="", stderr="", returncode=0))
+        assert out == ""
+
+    def test_timeout_message(self) -> None:
+        out = format_bang_output(BangTimeout(timeout=7))
+        assert "타임아웃" in out
+        assert "7s" in out
+        assert "REPL" in out
+
+
+# ---------------------------------------------------------------------------- handle_bang_input
+
+
+class TestHandleBangInput:
+    def test_empty_after_bang_returns_help_message(self) -> None:
+        out = handle_bang_input("!")
+        assert "!ls" in out
+        assert "실행할 명령" in out
+
+    def test_whitespace_only_after_bang_returns_help_message(self) -> None:
+        out = handle_bang_input("!   ")
+        assert "실행할 명령" in out
+
+    def test_uses_injected_runner(self) -> None:
+        calls: list[tuple[str, int]] = []
+
+        def fake_runner(cmd: str, timeout: int) -> BangResult:
+            calls.append((cmd, timeout))
+            return BangResult(stdout="injected\n", stderr="", returncode=0)
+
+        out = handle_bang_input("!echo hi", runner=fake_runner, timeout=8)
+        assert calls == [("echo hi", 8)]
+        assert "injected" in out
+
+    def test_strips_leading_whitespace_before_bang(self) -> None:
+        captured: list[str] = []
+
+        def fake_runner(cmd: str, timeout: int) -> BangResult:
+            captured.append(cmd)
+            return BangResult(stdout="", stderr="", returncode=0)
+
+        handle_bang_input("   !pwd", runner=fake_runner, timeout=5)
+        assert captured == ["pwd"]
+
+    def test_resolves_timeout_from_env_when_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(TIMEOUT_ENV_VAR, "13")
+        seen: list[int] = []
+
+        def fake_runner(cmd: str, timeout: int) -> BangResult:
+            seen.append(timeout)
+            return BangResult(stdout="", stderr="", returncode=0)
+
+        handle_bang_input("!ls", runner=fake_runner)
+        assert seen == [13]
+
+    def test_propagates_timeout_message(self) -> None:
+        def fake_runner(cmd: str, timeout: int) -> BangTimeout:
+            return BangTimeout(timeout=timeout)
+
+        out = handle_bang_input("!sleep 99", runner=fake_runner, timeout=4)
+        assert "타임아웃" in out
+        assert "4s" in out
+
+    def test_nonzero_exit_renders_exit_code(self) -> None:
+        def fake_runner(cmd: str, timeout: int) -> BangResult:
+            return BangResult(stdout="", stderr="oops\n", returncode=2)
+
+        out = handle_bang_input("!false", runner=fake_runner, timeout=5)
+        assert "[stderr] oops" in out
+        assert "[exit code: 2]" in out

--- a/tests/bang/test_repl_branch.py
+++ b/tests/bang/test_repl_branch.py
@@ -1,0 +1,171 @@
+"""``!cmd`` REPL 분기 통합 테스트.
+
+REPL 의 ``!`` 분기가:
+- ``mode.handle`` 을 호출하지 않는다(LLM/멀티턴 히스토리 미오염).
+- 슬래시 명령 디스패처를 호출하지 않는다.
+- 출력을 한 번 ``output_fn`` 으로 흘려보낸다.
+- 안내 메시지(``!`` 만 입력) 후에도 REPL 이 종료되지 않는다.
+- ``build_welcome_message`` / ``/help`` 출력에 사용 안내가 포함된다.
+
+본 테스트는 :func:`subprocess.run` 을 mock 으로 교체해 외부 명령을 실제로
+실행하지 않는다.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+from unittest import mock
+
+from sicode.bang import executor as bang_executor
+from sicode.commands import register_default_commands
+from sicode.modes.conversation import Conversation
+from sicode.repl import build_welcome_message, run_repl_with_inputs
+from tests.conftest import EchoMode
+
+
+class _FakeCompleted:
+    def __init__(self, stdout: str = "", stderr: str = "", returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def _patched_run(stdout: str = "", stderr: str = "", returncode: int = 0):  # type: ignore[no-untyped-def]
+    """``subprocess.run`` 을 고정 결과로 대체하는 컨텍스트 매니저."""
+
+    def fake_run(*args: Any, **kwargs: Any) -> _FakeCompleted:
+        return _FakeCompleted(stdout=stdout, stderr=stderr, returncode=returncode)
+
+    return mock.patch.object(bang_executor.subprocess, "run", side_effect=fake_run)
+
+
+class TestReplBangBranch:
+    def test_bang_does_not_invoke_mode_handle(self) -> None:
+        register_default_commands()
+        mode = EchoMode()
+        with _patched_run(stdout="files\n"):
+            outputs = run_repl_with_inputs(mode, ["!ls", "hello"])
+        # !ls 는 mode 로 가지 않는다. 'hello' 만 mode 에 도달.
+        assert mode.calls == ["hello"]
+        joined = "\n".join(outputs)
+        assert "files" in joined
+
+    def test_bang_outputs_stdout_only_for_zero_exit(self) -> None:
+        mode = EchoMode()
+        with _patched_run(stdout="hello-from-shell\n", stderr="", returncode=0):
+            outputs = run_repl_with_inputs(mode, ["!echo hi"])
+        joined = "\n".join(outputs)
+        assert "hello-from-shell" in joined
+        # 0 종료에서는 exit 코드 줄이 없다.
+        assert "[exit code:" not in joined
+
+    def test_bang_outputs_stderr_with_prefix_and_exit_code(self) -> None:
+        mode = EchoMode()
+        with _patched_run(stdout="", stderr="boom\n", returncode=1):
+            outputs = run_repl_with_inputs(mode, ["!fails"])
+        joined = "\n".join(outputs)
+        assert "[stderr] boom" in joined
+        assert "[exit code: 1]" in joined
+
+    def test_bang_timeout_keeps_repl_alive(
+        self, monkeypatch: "Any"
+    ) -> None:
+        # 짧은 타임아웃으로 mock 을 강제 발동.
+        monkeypatch.setenv("SICODE_BANG_TIMEOUT", "2")
+        mode = EchoMode()
+
+        def fake_run(*args: Any, **kwargs: Any) -> _FakeCompleted:
+            raise subprocess.TimeoutExpired(cmd="sleep 99", timeout=2)
+
+        with mock.patch.object(bang_executor.subprocess, "run", side_effect=fake_run):
+            outputs = run_repl_with_inputs(mode, ["!sleep 99", "after-timeout"])
+
+        joined = "\n".join(outputs)
+        assert "타임아웃" in joined
+        # REPL 이 계속 동작했는지: 다음 입력이 mode 에 도달했는지로 확인
+        assert mode.calls == ["after-timeout"]
+
+    def test_bang_only_produces_help_message(self) -> None:
+        mode = EchoMode()
+        # subprocess 가 호출되지 않아야 하므로 mock 으로 fail-fast 셋업
+        with mock.patch.object(
+            bang_executor.subprocess,
+            "run",
+            side_effect=AssertionError("subprocess.run must not be called"),
+        ):
+            outputs = run_repl_with_inputs(mode, ["!"])
+        joined = "\n".join(outputs)
+        assert "실행할 명령" in joined
+        assert "!ls" in joined
+        # mode.handle 도 호출되지 않음
+        assert mode.calls == []
+
+    def test_bang_with_only_whitespace_produces_help_message(self) -> None:
+        mode = EchoMode()
+        with mock.patch.object(
+            bang_executor.subprocess,
+            "run",
+            side_effect=AssertionError("subprocess.run must not be called"),
+        ):
+            outputs = run_repl_with_inputs(mode, ["!   "])
+        joined = "\n".join(outputs)
+        assert "실행할 명령" in joined
+        assert mode.calls == []
+
+    def test_bang_does_not_modify_conversation_history(self) -> None:
+        """OllamaChat (멀티턴) 모드의 history 가 ``!`` 명령으로 변하지 않아야 한다."""
+        conv = Conversation()
+        conv.add_user("first")
+        conv.add_assistant("answer")
+        before = list(conv.messages())  # 스냅샷
+
+        # bang 분기는 conversation 을 건드리지 않으므로, 직접 handle_bang_input 호출
+        # 검증과 REPL 통합 검증 양쪽이 모두 의미가 있다. 여기서는 REPL 통합으로
+        # 검증한다 — EchoMode 에는 conversation 이 없으므로 별도 가짜 모드를 사용.
+        from sicode.modes.base import BaseMode
+
+        class _ModeWithConv(BaseMode):
+            name = "with-conv"
+
+            def __init__(self, conversation: Conversation) -> None:
+                self.conversation = conversation
+                self.handle_calls: list[str] = []
+
+            def handle(self, user_input: str) -> str:
+                # 실제 OllamaMode 의 동작을 흉내내기 위해 conversation 에 누적
+                self.conversation.add_user(user_input)
+                self.conversation.add_assistant(f"echo:{user_input}")
+                self.handle_calls.append(user_input)
+                return f"echo:{user_input}"
+
+        mode = _ModeWithConv(conv)
+
+        with _patched_run(stdout="ok\n"):
+            run_repl_with_inputs(mode, ["!ls", "!pwd"])
+
+        # 두 번의 ``!`` 명령 후에도 conversation 의 messages 는 변하지 않아야 한다.
+        assert conv.messages() == before
+        # 또한 mode.handle 자체가 호출되지 않아야 한다.
+        assert mode.handle_calls == []
+
+
+class TestWelcomeAndHelpAdvertiseBang:
+    def test_welcome_message_advertises_bang_prefix(self) -> None:
+        mode = EchoMode()
+        msg = build_welcome_message(mode)
+        assert "!cmd" in msg
+        assert "!ls" in msg or "!git" in msg
+        # 보안 안내 문구
+        assert "주의" in msg or "직접 실행" in msg
+
+    def test_help_output_includes_bang_section(self) -> None:
+        register_default_commands()
+        mode = EchoMode()
+        outputs = run_repl_with_inputs(mode, ["/help"])
+        joined = "\n".join(outputs)
+        assert "!" in joined
+        # !cmd 또는 !<cmd> 형태로 표기되어야 한다
+        assert "!<cmd>" in joined or "!cmd" in joined
+        # 보안 주의 문구
+        assert "주의" in joined or "직접 실행" in joined


### PR DESCRIPTION
Closes #18

## Summary
- REPL 입력이 `!` 로 시작하면 슬래시 분기/모드 전달 이전에 셸 분기로 라우팅된다. `!ls`, `!git status`, `!cat foo | head -3` 처럼 셸 문법(파이프/리다이렉션/glob)을 그대로 쓸 수 있다.
- 셸 실행 로직은 신규 `sicode/bang/` 패키지에 분리(SRP). `repl.py` 의 분기는 2줄 추가로 최소화, `is_slash_command` 분기 직전에 위치한다.
- `build_welcome_message` 와 `/help` 출력에 사용법 + 보안 주의 문구를 추가했다.

## Implementation notes
- `subprocess.run` 옵션: `shell=True`, `capture_output=True`, `text=True`, `stdin=subprocess.DEVNULL`, `timeout=N`, `cwd=Path.cwd()`.
- 기본 타임아웃 60초. `SICODE_BANG_TIMEOUT`(초, 정수)로 재정의. 잘못된 값/0 이하는 기본값으로 안전 폴백.
- stdout 그대로 출력 / stderr 는 `[stderr] ` 접두사 / exit code 0 이외만 `[exit code: N]` 표시.
- `subprocess.TimeoutExpired` 시 `[bang] 명령이 타임아웃되었습니다 (Ns). REPL을 계속합니다.` 한 줄 출력 후 REPL 유지.
- `!` 단독·`!<공백>` 입력은 안내 메시지만 출력하고 `mode.handle` / 슬래시 디스패처 호출하지 않음.
- 멀티턴 `Conversation.messages()` 는 `!` 명령으로 절대 변하지 않음을 통합 테스트로 검증.
- Python 표준 라이브러리만 사용, `from __future__ import annotations` 로 Py3.8 호환.

## Design decisions
- `PrefixHandler` 추상 도입은 보류 (이슈 본문 "범위 외"). prefix 가 `/`, `!` 둘뿐이므로 단순 분기를 유지하고, 향후 `@` 등이 추가될 때 OCP 리팩터링을 별도 이슈로 검토.
- `BangResult` 와 `BangTimeout` 을 별도 dataclass 로 분리해 LSP 측면 압박을 피하고, `format_bang_output` 이 `isinstance` 분기로 명시 처리한다.
- `handle_bang_input` 은 `runner` 콜러블을 주입받아(DIP) 테스트가 `subprocess` mock 없이도 가능하다.

## Test plan
- [x] `tests/bang/test_executor.py` — 26 케이스 (분기 판정, 환경 변수 해석, subprocess 인자 통과, 타임아웃, stdout/stderr/exit code 포맷, 빈 명령 안내, runner 주입).
  - `subprocess.run` mock + `cat`/`echo` 실제 실행으로 stdin DEVNULL 봉쇄 검증.
- [x] `tests/bang/test_repl_branch.py` — 16 케이스 (REPL 통합: `mode.handle` 미호출, stdout/stderr/exit 표시, 타임아웃 후 REPL 유지, conversation history 미오염, welcome/help 안내 포함).
- [x] `python -m pytest` 결과: **389 passed** (baseline 347 + 신규 42). 회귀 0 건.

## Out of scope (이슈 본문 명시)
- 실시간 스트리밍 출력 — 별도 이슈
- 인터랙티브 셸(`!python`, `!vim`) — `stdin=DEVNULL` 로 봉쇄
- 허용/차단 명령 필터링 — 사용자 자율
- LLM 자동 전달/해석

🤖 Generated with [Claude Code](https://claude.com/claude-code)