### PR TITLE
feat: readline 기반 @심볼/슬래시 자동완성 추가 (#20)

### DIFF
--- a/sicode/main.py
+++ b/sicode/main.py
@@ -32,7 +32,12 @@ from sicode.modes.ollama import (
 )
 from sicode.modes.ollama_chat import OllamaChatClient
 from sicode.repl import run_repl
-from sicode.symbols import SymbolExpander, SymbolResolver
+from sicode.symbols import (
+    SymbolCompleter,
+    SymbolExpander,
+    SymbolResolver,
+    setup_readline_completer,
+)
 
 
 #: 환경 변수 이름들. 한 곳에 모아두어 테스트와 도큐먼트가 일관되게 참조한다.
@@ -237,6 +242,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         # 본 단계는 REPL 본문(repl.py) 변경 없이 동작한다 (OCP).
         default_registry.register(ModelCommand(model_registry=model_registry))
         default_registry.register(ModelsCommand(model_registry=model_registry))
+    # 이슈 #20: REPL 시작 직전에 readline Tab 자동완성을 1회 활성화한다.
+    # ``mode.symbol_resolver`` 가 :class:`SymbolResolver` 면 같은 인스턴스를
+    # 자동완성과 ``input_preprocessor`` 가 공유하므로 ``/clear`` 의 invalidate()
+    # 가 다음 Tab 자동완성에도 자연스럽게 반영된다(캐시 일관성).
+    # readline 모듈이 없거나 초기화에 실패해도 본 함수는 예외를 밖으로 던지지
+    # 않는다 — REPL 본문은 자동완성 없이도 정상 동작해야 한다 (graceful fallback).
+    _activate_readline_completion(mode)
+
     # ``builtins.input`` / ``builtins.print`` 를 호출 시점에 조회해서 전달한다.
     # 이렇게 해야 테스트에서 ``monkeypatch.setattr("builtins.input", ...)`` 같은
     # 패치가 정상적으로 적용된다.
@@ -245,6 +258,29 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         input_fn=lambda prompt: builtins.input(prompt),
         output_fn=lambda line: builtins.print(line),
     )
+
+
+def _activate_readline_completion(mode: BaseMode) -> None:
+    """모드에서 :class:`SymbolResolver` 를 꺼내 readline 자동완성을 활성화한다.
+
+    SRP: 자동완성 활성화 절차(리졸버 추출 → 컴플리터 생성 → readline 바인딩)를
+    한 함수에 모아 ``main()`` 흐름이 짧고 읽기 쉽게 유지된다.
+
+    실패 분기:
+        - ``mode`` 가 ``symbol_resolver`` 속성을 갖지 않거나 ``None`` 이면 자동완성
+          기능을 켜지 않는다(다른 모드와의 하위 호환성).
+        - readline 미존재/초기화 실패는 :func:`setup_readline_completer` 가 내부
+          에서 흡수해 ``False`` 를 돌려준다 — 본 함수도 예외를 밖으로 던지지
+          않는다.
+    """
+    resolver = getattr(mode, "symbol_resolver", None)
+    if resolver is None:
+        return
+    if not hasattr(resolver, "all_records"):
+        # 다른 형태의 객체가 들어 있으면 자동완성 후보 산출이 불가능하므로 패스.
+        return
+    completer = SymbolCompleter(resolver, registry=default_registry)
+    setup_readline_completer(completer, default_registry)
 
 
 if __name__ == "__main__":  # pragma: no cover - 직접 실행 진입점

--- a/sicode/symbols/__init__.py
+++ b/sicode/symbols/__init__.py
@@ -15,6 +15,11 @@ REPL 입력에서 ``@ClassName`` / ``@function_name`` 같은 토큰을 발견하
 
 from __future__ import annotations
 
+from sicode.symbols.completer import (
+    MAX_SYMBOL_CANDIDATES,
+    SymbolCompleter,
+    setup_readline_completer,
+)
 from sicode.symbols.expand import (
     DEFAULT_MAX_MATCHES,
     DEFAULT_MAX_SYMBOL_LINES,
@@ -32,9 +37,12 @@ __all__ = [
     "DEFAULT_MAX_FILE_BYTES",
     "DEFAULT_MAX_MATCHES",
     "DEFAULT_MAX_SYMBOL_LINES",
+    "MAX_SYMBOL_CANDIDATES",
+    "SymbolCompleter",
     "SymbolExpander",
     "SymbolIndexer",
     "SymbolRecord",
     "SymbolResolver",
     "expand_user_input",
+    "setup_readline_completer",
 ]

--- a/sicode/symbols/completer.py
+++ b/sicode/symbols/completer.py
@@ -1,0 +1,241 @@
+"""readline 기반 ``@심볼`` / ``/명령`` 자동완성기(이슈 #20).
+
+REPL 입력 도중 ``Tab`` 키를 누르면 readline 이 본 모듈의
+:class:`SymbolCompleter` 콜백을 ``state=0, 1, 2, ...`` 순으로 호출한다. 콜백은
+``state`` 마다 다음 후보 문자열을 반환하고, 더 이상 후보가 없으면 ``None`` 을
+반환한다. ``readline`` 의 호출 규약은 다음과 같다::
+
+    completer(text: str, state: int) -> Optional[str]
+
+설계 메모:
+    - SRP: 본 모듈은 "텍스트 prefix → 후보 문자열 리스트" 변환과 readline 초기화
+      두 가지 좁은 책임만 갖는다. 후보 데이터 자체(심볼 인덱스, 명령 레지스트리)
+      는 외부 객체에서 받는다.
+    - DIP: :class:`SymbolCompleter` 는 :class:`SymbolResolverProtocol`,
+      :class:`SlashRegistryProtocol` 추상에만 의존한다. 테스트는 작은 fake 객체를
+      주입해 readline 없이 콜백을 검증할 수 있다.
+    - ISP: 외부에 강요하는 메서드가 ``all_records()`` / ``commands()`` 두 개로
+      쪼개져 있어 큰 인터페이스 한 덩어리에 엮이지 않는다.
+    - 안전성: ``import readline`` 이 실패하는 환경(예: Windows 기본 파이썬,
+      pyreadline3 미설치)에서도 :func:`setup_readline_completer` 는 조용히 리턴해
+      REPL 본체가 동작 가능한 상태를 유지한다(graceful fallback).
+
+수용 기준 매핑(이슈 #20):
+    - ``@`` prefix 후보: :meth:`SymbolCompleter._complete_symbol`.
+    - ``/`` prefix 후보: :meth:`SymbolCompleter._complete_slash`.
+    - 매치 0건일 때 ``state=0`` 에 ``None`` 반환: :meth:`SymbolCompleter.__call__`.
+    - 후보 상한 20건: :data:`MAX_SYMBOL_CANDIDATES`.
+    - readline 미존재 환경에서 예외 없이 노옵: :func:`setup_readline_completer`.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional, Protocol
+
+from sicode.symbols.indexer import SymbolRecord
+
+
+#: 한 번의 ``@`` prefix 자동완성에서 노출할 최대 후보 수.
+#: 이슈 #20 정책: 인덱스에 심볼이 더 많아도 20건만 반환한다.
+MAX_SYMBOL_CANDIDATES: int = 20
+
+#: ``readline.set_completer_delims`` 에 설정할 구분자 문자열.
+#: 기본 delims 에는 ``@`` 가 포함돼 있어 ``@Symbol`` 입력 도중 Tab 을 누르면
+#: ``@`` 가 잘려 나간 ``Symbol`` 만 ``text`` 로 전달된다. 본 정책은 공백/탭/
+#: 개행만 토큰 경계로 보고, ``@`` 와 ``/`` 는 토큰 본체로 유지한다.
+COMPLETER_DELIMS: str = " \t\n"
+
+
+class SymbolResolverProtocol(Protocol):
+    """후보 산출에 필요한 :class:`SymbolResolver` 의 최소 계약(ISP)."""
+
+    def all_records(self) -> List[SymbolRecord]:  # pragma: no cover - 프로토콜
+        ...
+
+
+class SlashRegistryProtocol(Protocol):
+    """슬래시 명령 후보 산출에 필요한 레지스트리의 최소 계약(ISP).
+
+    실제 :class:`sicode.commands.registry.SlashCommandRegistry` 는
+    ``commands() -> List[SlashCommand]`` 를 제공한다. 본 프로토콜은 그중에서도
+    ``cmd.name`` 만 사용한다.
+    """
+
+    def commands(self) -> "List[_NamedCommand]":  # pragma: no cover - 프로토콜
+        ...
+
+
+class _NamedCommand(Protocol):
+    """슬래시 명령 후보에 사용할 최소 속성(``name``)만 요구하는 프로토콜."""
+
+    name: str
+
+
+class SymbolCompleter:
+    """``@심볼`` 과 ``/명령`` 자동완성을 제공하는 readline 콜백.
+
+    한 인스턴스는 ``(resolver, registry)`` 쌍 한 묶음을 표현한다. ``state=0``
+    일 때 ``text`` 의 prefix 분기에 따라 후보 리스트를 1회 계산해 캐시하고,
+    같은 ``text`` 에 대한 후속 ``state>=1`` 호출에서는 캐시된 리스트의 다음
+    인덱스를 반환한다. ``text`` 가 바뀌면 캐시가 자연스럽게 재계산된다.
+    """
+
+    def __init__(
+        self,
+        resolver: SymbolResolverProtocol,
+        registry: Optional[SlashRegistryProtocol] = None,
+    ) -> None:
+        """완성기를 초기화한다.
+
+        Args:
+            resolver: ``@`` 후보 산출에 사용할 심볼 리졸버. 본 객체는 ``all_records()``
+                만 호출되며, 캐시/invalidate 정책은 :class:`SymbolResolver` 본체가
+                책임진다.
+            registry: ``/`` 후보 산출에 사용할 슬래시 명령 레지스트리. ``None`` 이면
+                슬래시 자동완성은 후보 0건이 된다.
+        """
+        self._resolver: SymbolResolverProtocol = resolver
+        self._registry: Optional[SlashRegistryProtocol] = registry
+        # readline 콜백은 같은 ``text`` 로 ``state=0,1,2,...`` 를 순차 호출한다.
+        # 이를 위해 (text, candidates) 한 쌍을 캐시한다.
+        self._cached_text: Optional[str] = None
+        self._cached_candidates: List[str] = []
+
+    # ------------------------------------------------------------------ readline
+
+    def __call__(self, text: str, state: int) -> Optional[str]:
+        """readline 콜백 시그니처.
+
+        Args:
+            text: 현재 토큰(공백으로 분할된 마지막 단어). delims 를 공백 한정으로
+                재설정해 두면 ``@Symbol`` 또는 ``/cmd`` 가 통째로 들어온다.
+            state: 0 부터 시작해 ``None`` 반환 시까지 1 씩 증가하며 호출된다.
+
+        Returns:
+            ``state`` 번째 후보 문자열. 후보가 더 없으면 ``None``.
+        """
+        if state == 0:
+            self._cached_text = text
+            self._cached_candidates = self._build_candidates(text)
+
+        # 다른 ``text`` 에 대한 ``state>=1`` 호출은 비정상 흐름이지만, 방어적으로
+        # 빈 리스트로 취급해 ``None`` 을 돌려준다.
+        if text != self._cached_text:
+            return None
+
+        if state < 0 or state >= len(self._cached_candidates):
+            return None
+        return self._cached_candidates[state]
+
+    # ------------------------------------------------------------------ helpers
+
+    def _build_candidates(self, text: str) -> List[str]:
+        """``text`` 의 prefix 에 따라 후보 리스트를 만든다.
+
+        - ``@...`` : 심볼 prefix 일치(대소문자 구분, 알파벳 오름차순, 최대 20).
+        - ``/...`` : 슬래시 명령 prefix 일치(알파벳 오름차순).
+        - 그 외   : 빈 리스트(자동완성 비활성).
+        """
+        if text.startswith("@"):
+            return self._complete_symbol(text[1:])
+        if text.startswith("/"):
+            return self._complete_slash(text[1:])
+        return []
+
+    def _complete_symbol(self, prefix: str) -> List[str]:
+        """심볼 이름 prefix 일치 후보를 ``@Name`` 형태로 반환한다.
+
+        매칭 정책(이슈 #20):
+            - 대소문자 구분 prefix 일치.
+            - 같은 이름 중복 제거(파일이 달라도 이름이 같으면 후보 하나).
+            - 알파벳 오름차순 정렬.
+            - 최대 :data:`MAX_SYMBOL_CANDIDATES` 건.
+
+        ``prefix`` 가 빈 문자열이면 ``@`` 만 입력된 상태이므로 인덱스 전체에서
+        앞 20건을 보여 준다(이미 정렬·중복 제거된 결과).
+        """
+        records = self._resolver.all_records()
+        seen: "dict[str, None]" = {}
+        for record in records:
+            name = record.name
+            if not name.startswith(prefix):
+                continue
+            if name in seen:
+                continue
+            seen[name] = None
+        names = sorted(seen.keys())
+        limited = names[:MAX_SYMBOL_CANDIDATES]
+        return [f"@{name}" for name in limited]
+
+    def _complete_slash(self, prefix: str) -> List[str]:
+        """슬래시 명령 이름 prefix 일치 후보를 ``/name`` 형태로 반환한다.
+
+        ``SlashCommandRegistry.commands()`` 결과는 이미 알파벳 오름차순이지만,
+        본 메서드는 입력 정렬에 의존하지 않고 자체 정렬해 안정성을 보장한다.
+        """
+        if self._registry is None:
+            return []
+        names: List[str] = []
+        for cmd in self._registry.commands():
+            cmd_name = getattr(cmd, "name", "")
+            if not cmd_name:
+                continue
+            if cmd_name.startswith(prefix):
+                names.append(cmd_name)
+        names.sort()
+        return [f"/{name}" for name in names]
+
+
+def setup_readline_completer(
+    completer: SymbolCompleter,
+    registry: Optional[SlashRegistryProtocol] = None,
+) -> bool:
+    """readline 에 ``completer`` 를 등록하고 Tab 자동완성을 활성화한다.
+
+    Args:
+        completer: 등록할 :class:`SymbolCompleter` 인스턴스.
+        registry: 본 함수는 슬래시 자동완성을 위해 별도로 레지스트리를 사용하지
+            않는다(``completer`` 가 이미 보유). 인자는 호출 측 대칭성/추후 확장
+            용으로 받아 두며, ``None`` 또는 임의 객체를 넘겨도 동작에 영향 없다.
+
+    Returns:
+        readline 가 사용 가능해 정상 등록된 경우 ``True``, 환경에 readline 모듈이
+        없거나 초기화 단계에서 예외가 난 경우 ``False``. 어느 쪽이든 예외는
+        밖으로 던지지 않는다(graceful fallback — REPL 본체는 계속 살아 있다).
+
+    Notes:
+        - ``readline.set_completer_delims`` 를 :data:`COMPLETER_DELIMS` 로 재설정
+          한다. 기본값에는 ``@`` 가 포함돼 ``@Symbol`` 의 ``@`` 가 잘려 나가므로
+          본 옵션은 필수다.
+        - ``readline.parse_and_bind("tab: complete")`` 로 Tab 키에 자동완성을
+          바인딩한다. macOS 의 libedit 호환 readline 도 같은 문자열을 인식한다.
+    """
+    try:
+        import readline  # type: ignore[import-not-found]
+    except Exception:
+        return False
+
+    try:
+        readline.set_completer(completer)
+        readline.set_completer_delims(COMPLETER_DELIMS)
+        readline.parse_and_bind("tab: complete")
+    except Exception:
+        # 일부 환경(특히 stub readline)에서 set_completer 가 NotImplementedError
+        # 등을 던질 수 있다. 본 경로는 REPL 시작을 막지 않는다.
+        return False
+    return True
+
+
+#: 외부에서 ``setup_readline_completer`` 의 본문 변경 없이 readline 모듈을
+#: 교체하고 싶을 때 사용하는 임포트 hook 자리. 현재는 노출하지 않는다.
+_ImportHook = Callable[[], object]
+
+
+__all__ = [
+    "COMPLETER_DELIMS",
+    "MAX_SYMBOL_CANDIDATES",
+    "SlashRegistryProtocol",
+    "SymbolCompleter",
+    "SymbolResolverProtocol",
+    "setup_readline_completer",
+]

--- a/tests/symbols/test_completer.py
+++ b/tests/symbols/test_completer.py
@@ -1,0 +1,373 @@
+"""SymbolCompleter / setup_readline_completer 단위 테스트(이슈 #20).
+
+본 테스트는 실제 ``readline`` 모듈에 의존하지 않고 :class:`SymbolCompleter`
+콜백을 직접 호출해 후보 산출 로직을 검증한다. ``setup_readline_completer`` 는
+별도 테스트에서 readline 가짜 객체를 ``sys.modules`` 에 주입해 흐름만 확인한다.
+
+설계 메모:
+    - 테스트는 작고 의도가 명확한 fake resolver/registry 객체에만 의존한다 (DIP).
+    - 통합 테스트는 ``test_main.py`` 통합 스위트가 이미 main 흐름을 커버하므로,
+      본 모듈은 단위 수준의 콜백 시그니처/경계 케이스에 집중한다 (SRP).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import List, Optional
+
+import pytest
+
+from sicode.symbols.completer import (
+    COMPLETER_DELIMS,
+    MAX_SYMBOL_CANDIDATES,
+    SymbolCompleter,
+    setup_readline_completer,
+)
+from sicode.symbols.indexer import SymbolRecord
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+def _record(name: str, kind: str = "class") -> SymbolRecord:
+    """경로/라인은 의미 없는 더미를 채우고 이름만 의미 있는 SymbolRecord 생성."""
+    return SymbolRecord(
+        name=name,
+        kind=kind,
+        rel_path="dummy.py",
+        start_line=1,
+        end_line=1,
+        source=f"class {name}:\n    pass\n",
+    )
+
+
+class FakeResolver:
+    """``all_records()`` 만 노출하는 최소 리졸버 더블 (DIP/ISP)."""
+
+    def __init__(self, records: List[SymbolRecord]) -> None:
+        self._records = records
+
+    def all_records(self) -> List[SymbolRecord]:
+        return list(self._records)
+
+
+class FakeCommand:
+    """``name`` 속성만 있는 슬래시 명령 더블."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class FakeRegistry:
+    """``commands()`` 만 노출하는 슬래시 레지스트리 더블."""
+
+    def __init__(self, names: List[str]) -> None:
+        self._cmds = [FakeCommand(n) for n in names]
+
+    def commands(self) -> List[FakeCommand]:
+        return list(self._cmds)
+
+
+# ---------------------------------------------------------------------------
+# Symbol prefix 자동완성
+# ---------------------------------------------------------------------------
+
+
+class TestSymbolCompletionByPrefix:
+    def test_returns_at_prefixed_match_for_state_zero(self) -> None:
+        # Given: 인덱스에 ConversationMode / ConvergenceTool / Other 가 있다
+        resolver = FakeResolver(
+            [
+                _record("ConversationMode"),
+                _record("ConvergenceTool"),
+                _record("Other"),
+            ]
+        )
+        completer = SymbolCompleter(resolver)
+
+        first = completer("@Conv", 0)
+        assert first is not None
+        assert first.startswith("@")
+        # ConvergenceTool 이 알파벳 순으로 ConversationMode 보다 앞.
+        assert first == "@ConvergenceTool"
+
+    def test_returns_none_when_state_exceeds_candidates(self) -> None:
+        resolver = FakeResolver([_record("ConversationMode")])
+        completer = SymbolCompleter(resolver)
+
+        assert completer("@Conv", 0) == "@ConversationMode"
+        # 후보가 1건이므로 state=1 이면 None.
+        assert completer("@Conv", 1) is None
+
+    def test_returns_none_for_state_zero_when_no_match(self) -> None:
+        resolver = FakeResolver([_record("Foo"), _record("Bar")])
+        completer = SymbolCompleter(resolver)
+        assert completer("@Zzz", 0) is None
+
+    def test_results_are_sorted_alphabetically(self) -> None:
+        resolver = FakeResolver(
+            [
+                _record("Zeta"),
+                _record("Alpha"),
+                _record("Mu"),
+            ]
+        )
+        completer = SymbolCompleter(resolver)
+        # 접두사 ``@`` 만 입력 → 모든 심볼이 후보.
+        results: List[str] = []
+        idx = 0
+        while True:
+            value = completer("@", idx)
+            if value is None:
+                break
+            results.append(value)
+            idx += 1
+        assert results == ["@Alpha", "@Mu", "@Zeta"]
+
+    def test_prefix_match_is_case_sensitive(self) -> None:
+        # 이슈 본문 정책: prefix 일치(대소문자 구분).
+        resolver = FakeResolver([_record("ConversationMode")])
+        completer = SymbolCompleter(resolver)
+        # 소문자로 시작하는 prefix 는 매치되지 않는다.
+        assert completer("@conv", 0) is None
+
+    def test_duplicate_names_are_collapsed(self) -> None:
+        # 같은 이름이 두 파일에 존재해도 후보 한 건만.
+        rec_a = SymbolRecord(
+            name="DupName",
+            kind="class",
+            rel_path="a.py",
+            start_line=1,
+            end_line=2,
+            source="",
+        )
+        rec_b = SymbolRecord(
+            name="DupName",
+            kind="class",
+            rel_path="b.py",
+            start_line=1,
+            end_line=2,
+            source="",
+        )
+        resolver = FakeResolver([rec_a, rec_b])
+        completer = SymbolCompleter(resolver)
+
+        assert completer("@Dup", 0) == "@DupName"
+        assert completer("@Dup", 1) is None
+
+    def test_caps_candidates_at_twenty(self) -> None:
+        # 25개의 같은 prefix 심볼이 있어도 20건만 노출.
+        records = [_record(f"Foo{i:02d}") for i in range(25)]
+        resolver = FakeResolver(records)
+        completer = SymbolCompleter(resolver)
+
+        results: List[str] = []
+        idx = 0
+        while True:
+            value = completer("@Foo", idx)
+            if value is None:
+                break
+            results.append(value)
+            idx += 1
+        assert len(results) == MAX_SYMBOL_CANDIDATES
+        # 정렬 안정성: 첫 후보는 알파벳상 가장 작은 Foo00.
+        assert results[0] == "@Foo00"
+        assert results[-1] == "@Foo19"
+
+
+# ---------------------------------------------------------------------------
+# Slash command 자동완성
+# ---------------------------------------------------------------------------
+
+
+class TestSlashCompletion:
+    def test_slash_prefix_returns_command_name(self) -> None:
+        registry = FakeRegistry(["clear", "exit", "help"])
+        completer = SymbolCompleter(FakeResolver([]), registry=registry)
+
+        assert completer("/cl", 0) == "/clear"
+        assert completer("/cl", 1) is None
+
+    def test_slash_only_lists_all_commands_alphabetically(self) -> None:
+        registry = FakeRegistry(["help", "exit", "clear"])
+        completer = SymbolCompleter(FakeResolver([]), registry=registry)
+
+        results: List[str] = []
+        idx = 0
+        while True:
+            value = completer("/", idx)
+            if value is None:
+                break
+            results.append(value)
+            idx += 1
+        assert results == ["/clear", "/exit", "/help"]
+
+    def test_slash_no_match_returns_none(self) -> None:
+        registry = FakeRegistry(["clear", "exit"])
+        completer = SymbolCompleter(FakeResolver([]), registry=registry)
+        assert completer("/zzz", 0) is None
+
+    def test_slash_without_registry_returns_none(self) -> None:
+        # 레지스트리 미주입 시 슬래시 자동완성은 비활성.
+        completer = SymbolCompleter(FakeResolver([]))
+        assert completer("/cl", 0) is None
+
+
+# ---------------------------------------------------------------------------
+# 일반 텍스트 / 캐시 동작
+# ---------------------------------------------------------------------------
+
+
+class TestCallableContract:
+    def test_plain_text_returns_none(self) -> None:
+        # ``@`` 도 ``/`` 도 아닌 일반 텍스트는 후보 0건.
+        resolver = FakeResolver([_record("Foo")])
+        completer = SymbolCompleter(resolver)
+        assert completer("hello", 0) is None
+
+    def test_state_indices_are_iterated_until_none(self) -> None:
+        resolver = FakeResolver([_record("Foo"), _record("Bar")])
+        completer = SymbolCompleter(resolver)
+
+        # ``@`` → 모든 후보 노출.
+        assert completer("@", 0) == "@Bar"
+        assert completer("@", 1) == "@Foo"
+        assert completer("@", 2) is None
+
+    def test_changing_text_recomputes_candidates(self) -> None:
+        resolver = FakeResolver([_record("Foo"), _record("Bar")])
+        completer = SymbolCompleter(resolver)
+
+        # state=0 호출이 캐시를 갱신해야 한다.
+        assert completer("@F", 0) == "@Foo"
+        assert completer("@B", 0) == "@Bar"
+        # 새 text 의 첫 호출은 새 후보 리스트로 재계산되어야 함.
+        assert completer("@B", 1) is None
+
+    def test_negative_state_returns_none(self) -> None:
+        resolver = FakeResolver([_record("Foo")])
+        completer = SymbolCompleter(resolver)
+        # 비정상 state 입력은 None 으로 흡수한다.
+        completer("@F", 0)
+        assert completer("@F", -1) is None
+
+
+# ---------------------------------------------------------------------------
+# setup_readline_completer 동작
+# ---------------------------------------------------------------------------
+
+
+class _FakeReadline:
+    """``readline`` 모듈 인터페이스를 흉내내는 더블."""
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.completer: Optional[object] = None
+        self.delims: Optional[str] = None
+        self.bind_args: List[str] = []
+        self._fail = fail
+
+    def set_completer(self, completer: object) -> None:
+        if self._fail:
+            raise RuntimeError("readline init failed")
+        self.completer = completer
+
+    def set_completer_delims(self, delims: str) -> None:
+        self.delims = delims
+
+    def parse_and_bind(self, command: str) -> None:
+        self.bind_args.append(command)
+
+
+class TestSetupReadline:
+    def test_returns_false_when_readline_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # readline 임포트가 ImportError 를 던지도록 만든다.
+        original_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+        def _failing_import(name, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if name == "readline":
+                raise ImportError("readline not available in this environment")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", _failing_import)
+
+        completer = SymbolCompleter(FakeResolver([]))
+        # 예외가 밖으로 새지 않아야 한다.
+        ok = setup_readline_completer(completer)
+        assert ok is False
+
+    def test_registers_completer_when_readline_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = _FakeReadline()
+        monkeypatch.setitem(sys.modules, "readline", fake)  # type: ignore[arg-type]
+
+        completer = SymbolCompleter(FakeResolver([]))
+        ok = setup_readline_completer(completer)
+
+        assert ok is True
+        assert fake.completer is completer
+        assert fake.delims == COMPLETER_DELIMS
+        assert "tab: complete" in fake.bind_args
+
+    def test_returns_false_when_initialization_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = _FakeReadline(fail=True)
+        monkeypatch.setitem(sys.modules, "readline", fake)  # type: ignore[arg-type]
+
+        completer = SymbolCompleter(FakeResolver([]))
+        # readline 호출 도중 예외가 발생해도 외부로 던지지 않는다.
+        ok = setup_readline_completer(completer)
+        assert ok is False
+
+    def test_completer_delims_does_not_strip_at_or_slash(self) -> None:
+        # ``@`` 와 ``/`` 는 토큰 본체 — delims 는 공백/탭/개행만 허용.
+        assert "@" not in COMPLETER_DELIMS
+        assert "/" not in COMPLETER_DELIMS
+        assert " " in COMPLETER_DELIMS
+        assert "\t" in COMPLETER_DELIMS
+        assert "\n" in COMPLETER_DELIMS
+
+
+# ---------------------------------------------------------------------------
+# 통합: SymbolResolver 와 함께 (캐시 일관성)
+# ---------------------------------------------------------------------------
+
+
+class TestWithRealSymbolResolver:
+    """실제 :class:`SymbolResolver` + in-memory 인덱서로 통합 동작 확인."""
+
+    def test_completer_uses_resolver_cache_via_all_records(self) -> None:
+        from sicode.symbols.resolver import SymbolResolver
+
+        class StaticIndexer:
+            """``build()`` 가 고정 레코드 리스트를 돌려주는 in-memory 인덱서."""
+
+            def __init__(self, records: List[SymbolRecord]) -> None:
+                self._records = records
+                self.build_calls = 0
+
+            def build(self) -> List[SymbolRecord]:
+                self.build_calls += 1
+                return list(self._records)
+
+        records = [_record("Alpha"), _record("Beta"), _record("Gamma")]
+        indexer = StaticIndexer(records)
+        resolver = SymbolResolver(indexer=indexer)
+        completer = SymbolCompleter(resolver)
+
+        # 첫 호출이 lazy 인덱싱을 트리거.
+        assert completer("@A", 0) == "@Alpha"
+        # 두 번째 호출은 캐시 히트 — build() 가 추가 호출되지 않아야 한다.
+        assert completer("@B", 0) == "@Beta"
+        assert indexer.build_calls == 1
+
+        # invalidate 후 다음 호출은 재인덱싱.
+        resolver.invalidate()
+        assert completer("@G", 0) == "@Gamma"
+        assert indexer.build_calls == 2


### PR DESCRIPTION
Closes #20

## 변경 요약
REPL 입력 도중 `Tab` 키로 `@심볼` 과 `/명령` 을 자동완성할 수 있도록 readline 콜백을 신설하고 main 진입점에서 1회 활성화한다. readline 부재/초기화 실패는 graceful fallback 으로 흡수해 REPL 본체 동작에 영향이 없다.

## 변경된 파일
- `sicode/symbols/completer.py` (신규): `SymbolCompleter` 클래스(readline 콜백 시그니처 `(text, state) -> Optional[str]`)와 `setup_readline_completer` 헬퍼.
- `sicode/symbols/__init__.py`: 신규 심볼(`SymbolCompleter`, `setup_readline_completer`, `MAX_SYMBOL_CANDIDATES`) 공개.
- `sicode/main.py`: `_activate_readline_completion(mode)` 추가. 모드에서 `symbol_resolver` 를 꺼내 자동완성과 입력 변환이 같은 인스턴스를 공유하도록 묶음(`/clear` invalidate 정책 일관성).
- `tests/symbols/test_completer.py` (신규): 콜백 단위 테스트 20케이스.

## 핵심 설계 결정
- **DIP/ISP**: `SymbolCompleter` 는 `SymbolResolverProtocol(all_records)` / `SlashRegistryProtocol(commands)` 두 작은 계약에만 의존한다. 테스트는 fake 객체로 readline 없이 직접 호출.
- **delims**: `readline.set_completer_delims` 를 `" \t\n"` 한정으로 재설정해 `@Symbol` / `/cmd` 가 통째로 `text` 로 전달되게 함(기본 delims 에 `@` 가 포함되는 문제 해결).
- **graceful fallback**: `import readline` 실패 또는 readline API 호출 도중 예외 시 `setup_readline_completer` 가 `False` 를 돌려주며 호출 측에 예외를 던지지 않음.
- **후보 정책(이슈 본문 그대로)**: `@` 는 prefix 일치(대소문자 구분), 알파벳 오름차순, 중복 이름 collapse, 최대 20건. 매치 0건이면 `state=0` 에 `None` (readline 기본 beep 동작에 위임).

## 검증
- `python -m pytest -q` → **367 passed** (기존 347 + 신규 20).
- 회귀 테스트(`test_repl.py`, `tests/symbols/*`, `test_main*.py`) 모두 통과.
- `EchoMode` 처럼 `symbol_resolver` 속성이 없는 모드도 main 진입에 영향 없음을 main 통합 테스트로 간접 검증.

## 범위 외 (이슈 본문 명시)
- Windows `pyreadline3` 완전 지원
- raw 터미널 후보 팝업
- 심볼 본문 인라인 미리보기
- 파일 경로 자동완성