### PR TITLE
docs: 회의록·일지 (#17, #18)

### DIFF
--- a/docs/daily/2026-05-04.md
+++ b/docs/daily/2026-05-04.md
@@ -1,0 +1,29 @@
+# 2026-05-04 작업일지
+
+> 자동 생성됨. 서기 에이전트가 새 작업 완료 시마다 갱신.
+
+## 요약
+
+- 총 작업: **2건**
+- 승인 완료: 2건
+- 수동검토 필요: 0건
+
+## 작업 목록
+
+### #17 @symbol 자동 확장으로 REPL 입력에 정의 코드 첨부
+
+- 상태: **✓ 승인 (머지 완료)**
+- 이슈: https://github.com/kim-taehan/si-code/issues/17
+- PR: https://github.com/kim-taehan/si-code/pull/19
+- 브랜치: `agent/issue-17`
+- 리뷰 라운드: 1회
+- 상세 회의록: [issue-17-@symbol 자동 확장.md](../runs/2026-05-04/issue-17-@symbol%20자동%20확장.md)
+
+### #18 ! 셸 prefix로 REPL에서 직접 셸 명령 실행
+
+- 상태: **✓ 승인 (머지 완료)**
+- 이슈: https://github.com/kim-taehan/si-code/issues/18
+- PR: https://github.com/kim-taehan/si-code/pull/21
+- 브랜치: `agent/issue-18`
+- 리뷰 라운드: 1회
+- 상세 회의록: [issue-18-! 셸 prefix.md](../runs/2026-05-04/issue-18-!%20셸%20prefix.md)

--- a/docs/runs/2026-05-04/issue-17-@symbol 자동 확장.md
+++ b/docs/runs/2026-05-04/issue-17-@symbol 자동 확장.md
@@ -1,0 +1,49 @@
+---
+issue_num: 17
+issue_url: https://github.com/kim-taehan/si-code/issues/17
+pr_url: https://github.com/kim-taehan/si-code/pull/19
+branch: agent/issue-17
+title: "@symbol 자동 확장으로 REPL 입력에 정의 코드 첨부"
+status: approved
+rounds: 1
+date: 2026-05-04
+created_at: 2026-05-04T00:00:00+09:00
+---
+
+# 실행 기록: @symbol 자동 확장으로 REPL 입력에 정의 코드 첨부
+
+## TL;DR
+
+REPL 입력 시 `@심볼명` 패턴을 인식해 해당 심볼의 정의 코드를 자동으로 입력에 첨부하는 기능을 구현했다. `sicode/symbols/` 패키지(indexer/resolver/expander)를 신설하고 `OllamaMode`에 `input_preprocessor` 옵셔널 주입으로 REPL 본문은 무수정(OCP) 유지했다. `/clear` 명령 시 심볼 캐시가 정확히 무효화되며, 50개 신규 테스트를 포함한 347개 전체 pass로 라운드 1에서 즉시 승인·머지되었다.
+
+## 사용자 요청
+
+REPL에서 `@함수명` 또는 `@클래스명`을 입력하면 해당 심볼의 정의 코드가 자동으로 프롬프트에 첨부되도록 해 달라는 요청. **핵심 의도**: 별도 복사·붙여넣기 없이 대화 중 심볼을 참조해 LLM이 실제 구현 코드를 컨텍스트로 받을 수 있게 함.
+
+## 분석가 결과 요약
+
+`@token` 패턴 인식·인덱싱·확장 로직의 SRP 분리, `OllamaMode`와 REPL 본문 무수정 조건(OCP), `/clear` 호출 시 심볼 캐시 무효화, 시크릿 파일(`.env`, `credentials`) 확장 차단이 수용기준으로 정의되었다.
+
+## 개발자 작업 (라운드별)
+
+### 라운드 1
+
+- 변경된 파일: `sicode/symbols/__init__.py`, `sicode/symbols/indexer.py`, `sicode/symbols/resolver.py`, `sicode/symbols/expand.py`, `OllamaMode` 수정(`input_preprocessor` 옵셔널 주입), `_handle_chat`/`_handle_legacy` 1라인 통합, `ClearCommand` duck-typing 추가, `main.py` 진입점 업데이트
+- 핵심 로직: `main.py`가 `SymbolResolver`/`SymbolExpander`를 한 번 생성해 모드와 expander에 공유; `ClearCommand`가 `mode.symbol_resolver.invalidate()` duck-typing 호출로 `/clear` 무효화가 다음 `@token` 입력의 lazy 인덱싱에 정확 반영; 시크릿 파일 확장 차단 내장
+- 테스트: 신규 50개 테스트, 전체 347 pass(297+50, 회귀 0)
+
+## 리뷰 히스토리
+
+### 라운드 1
+
+- 판정: [APPROVED]
+- 핵심 지적: 9개 수용기준 모두 충족, SOLID 분리(SRP/OCP/DIP) 및 시크릿 차단 모두 만족, Critical 없음
+
+## 최종 상태
+
+- 승인: 9개 수용기준 전부 충족, 347개 테스트 pass(회귀 0), 머지 커밋 e1db7fc (UTC 2026-05-03 23:53)
+
+## 후속 조치
+
+- 알려진 한계/가정: 심볼 인덱싱은 lazy 방식으로 첫 `@token` 입력 시 수행; 대규모 코드베이스에서 초기 인덱싱 지연 가능성 있음
+- 추후 작업: PR #22(`@` 자동완성) 머지 후 Tab 키 자동완성과의 통합 검토

--- a/docs/runs/2026-05-04/issue-18-! 셸 prefix.md
+++ b/docs/runs/2026-05-04/issue-18-! 셸 prefix.md
@@ -1,0 +1,51 @@
+---
+issue_num: 18
+issue_url: https://github.com/kim-taehan/si-code/issues/18
+pr_url: https://github.com/kim-taehan/si-code/pull/21
+branch: agent/issue-18
+title: "! 셸 prefix로 REPL에서 직접 셸 명령 실행"
+status: approved
+rounds: 1
+date: 2026-05-04
+created_at: 2026-05-04T00:00:00+09:00
+---
+
+# 실행 기록: ! 셸 prefix로 REPL에서 직접 셸 명령 실행
+
+## TL;DR
+
+REPL 입력 앞에 `!`를 붙이면 해당 입력을 셸 명령으로 직접 실행하는 기능을 구현했다. `sicode/bang/` 패키지를 신설하고 `repl.py`에 2줄 분기만 추가(REPL 무수정에 가까운 OCP)하며, `Conversation` 히스토리를 오염시키지 않도록 통합 검증했다. 환경변수 `SICODE_BANG_TIMEOUT`으로 타임아웃 조정 가능하며, 보안 안내 문구를 환영 메시지·`/help` 출력에 포함했다. 42개 신규 테스트를 포함한 389개 전체 pass로 라운드 1에서 즉시 승인·머지되었다.
+
+## 사용자 요청
+
+REPL 내에서 `!ls`, `!git status` 등 셸 명령을 직접 입력해 실행 결과를 확인할 수 있도록 해 달라는 요청. **핵심 의도**: 별도 터미널 전환 없이 REPL 세션 안에서 파일 시스템 탐색·빌드 명령 등을 즉시 실행.
+
+## 분석가 결과 요약
+
+`!` prefix 인식, `subprocess` 기반 실행 래퍼, 타임아웃 처리, stderr 구분 출력, `Conversation` 히스토리 미오염, 보안 경고 문구 포함, `SICODE_BANG_TIMEOUT` 환경변수 지원이 수용기준으로 정의되었다.
+
+## 개발자 작업 (라운드별)
+
+### 라운드 1
+
+- 변경된 파일: `sicode/bang/__init__.py`, `sicode/bang/executor.py`(BangResult/BangTimeout dataclass + 실행 래퍼 + 출력 포맷터 + runner 주입 진입점), `sicode/repl.py`(is_slash_command 직전 `!` 분기 2줄), 환영 메시지 및 `/help` 출력 업데이트, `main.py` 진입점 업데이트
+- 핵심 로직: `subprocess.run(shell=True, capture_output=True, text=True, stdin=DEVNULL, timeout=N, cwd=Path.cwd())`로 현재 작업 디렉토리 기준 실행; `[stderr]` 접두사·`[exit code: N]`·타임아웃 메시지로 출력 포맷 구분; `BangResult`/`BangTimeout` dataclass 분리로 LSP 안전; `Conversation` history 미오염 통합 검증
+- 테스트: 신규 42개 테스트, 전체 389 pass(347+42, 회귀 0)
+
+## 리뷰 히스토리
+
+### 라운드 1
+
+- 판정: [APPROVED]
+- 핵심 지적: 9개 수용기준 모두 충족, SRP/DIP 명확, 보안 안내 완비, Critical 없음. Suggestion 2건(후속 cleanup 후보):
+  1. 타입 힌트 범위 확대 검토
+  2. conftest 이동 검토
+
+## 최종 상태
+
+- 승인: 9개 수용기준 전부 충족, 389개 테스트 pass(회귀 0), 머지 커밋 (2026-05-04 머지)
+
+## 후속 조치
+
+- 알려진 한계/가정: `shell=True` 사용으로 셸 인젝션 위험이 있어 사용자에게 보안 안내 문구 제공; 신뢰할 수 없는 입력 자동 실행 시 주의 필요
+- 추후 작업: 리뷰어 Suggestion 2건(타입 힌트 폭, conftest 이동) cleanup


### PR DESCRIPTION
## Summary

- 이슈 #17 (@symbol 자동 확장) 회의록 작성 — PR #19 승인·머지 기록
- 이슈 #18 (! 셸 prefix) 회의록 작성 — PR #21 승인·머지 기록
- 2026-05-04 일일 작업일지 생성 (총 2건, 승인 완료 2건, 수동검토 0건)

## 파일 목록

- `docs/runs/2026-05-04/issue-17-@symbol 자동 확장.md`
- `docs/runs/2026-05-04/issue-18-! 셸 prefix.md`
- `docs/daily/2026-05-04.md`

## 참고

PR #22 (`@` 자동완성)는 머지 전으로 이번 일지에 미포함. 후속 작업 시 추가 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)