### PR TITLE
feat: @file token autocompletion and expand support (#24)

### DIFF
--- a/sicode/symbols/__init__.py
+++ b/sicode/symbols/__init__.py
@@ -1,26 +1,33 @@
-"""@심볼 자동 확장 패키지(이슈 #17).
+"""@심볼 / @파일 자동 확장 패키지(이슈 #17, #24).
 
-REPL 입력에서 ``@ClassName`` / ``@function_name`` 같은 토큰을 발견하면 작업
-디렉토리의 Python 소스에서 해당 심볼의 정의 코드를 찾아 user message 본문
-끝에 자동 첨부한다.
+REPL 입력에서 ``@ClassName`` / ``@function_name`` / ``@README.md`` /
+``@sicode/repl.py`` 같은 토큰을 발견하면 작업 디렉토리의 Python 소스 또는 파일
+본문을 user message 끝에 자동 첨부한다.
 
 서브모듈 구성(SRP):
     - :mod:`sicode.symbols.indexer`: 작업 디렉토리를 한 번 스캔해 ``ClassDef`` /
-      ``FunctionDef`` 노드를 인덱싱한다.
+      ``FunctionDef`` 노드(:class:`SymbolRecord`) 와 일반 파일
+      (:class:`FileRecord`) 을 인덱싱한다. :class:`CompositeIndexer` 가 두
+      인덱서를 묶는다.
     - :mod:`sicode.symbols.resolver`: 인덱스를 캐시하고 토큰을 매칭(정확 일치 →
-      대소문자 무시 부분 일치)으로 찾는 역할.
+      대소문자 무시 부분 일치)으로 찾는 역할. 심볼/파일 검색 메서드를 분리해
+      제공한다(``find`` / ``find_files``).
     - :mod:`sicode.symbols.expand`: 사용자 입력에서 ``@토큰`` 을 추출해 매칭된
-      코드 블록을 본문 끝에 append 한다.
+      코드 블록 또는 파일 본문을 본문 끝에 append 한다.
+    - :mod:`sicode.symbols.completer`: readline Tab 자동완성 콜백.
 """
 
 from __future__ import annotations
 
 from sicode.symbols.completer import (
+    MAX_CANDIDATES,
+    MAX_FILE_CANDIDATES,
     MAX_SYMBOL_CANDIDATES,
     SymbolCompleter,
     setup_readline_completer,
 )
 from sicode.symbols.expand import (
+    DEFAULT_MAX_FILE_LINES,
     DEFAULT_MAX_MATCHES,
     DEFAULT_MAX_SYMBOL_LINES,
     SymbolExpander,
@@ -28,15 +35,25 @@ from sicode.symbols.expand import (
 )
 from sicode.symbols.indexer import (
     DEFAULT_MAX_FILE_BYTES,
+    CompositeIndexer,
+    FileIndexer,
+    FileRecord,
     SymbolIndexer,
     SymbolRecord,
+    make_default_composite_indexer,
 )
 from sicode.symbols.resolver import SymbolResolver
 
 __all__ = [
+    "CompositeIndexer",
     "DEFAULT_MAX_FILE_BYTES",
+    "DEFAULT_MAX_FILE_LINES",
     "DEFAULT_MAX_MATCHES",
     "DEFAULT_MAX_SYMBOL_LINES",
+    "FileIndexer",
+    "FileRecord",
+    "MAX_CANDIDATES",
+    "MAX_FILE_CANDIDATES",
     "MAX_SYMBOL_CANDIDATES",
     "SymbolCompleter",
     "SymbolExpander",
@@ -44,5 +61,6 @@ __all__ = [
     "SymbolRecord",
     "SymbolResolver",
     "expand_user_input",
+    "make_default_composite_indexer",
     "setup_readline_completer",
 ]

--- a/sicode/symbols/completer.py
+++ b/sicode/symbols/completer.py
@@ -1,4 +1,4 @@
-"""readline 기반 ``@심볼`` / ``/명령`` 자동완성기(이슈 #20).
+"""readline 기반 ``@심볼`` / ``@파일`` / ``/명령`` 자동완성기(이슈 #20, #24).
 
 REPL 입력 도중 ``Tab`` 키를 누르면 readline 이 본 모듈의
 :class:`SymbolCompleter` 콜백을 ``state=0, 1, 2, ...`` 순으로 호출한다. 콜백은
@@ -9,35 +9,43 @@ REPL 입력 도중 ``Tab`` 키를 누르면 readline 이 본 모듈의
 
 설계 메모:
     - SRP: 본 모듈은 "텍스트 prefix → 후보 문자열 리스트" 변환과 readline 초기화
-      두 가지 좁은 책임만 갖는다. 후보 데이터 자체(심볼 인덱스, 명령 레지스트리)
-      는 외부 객체에서 받는다.
+      두 가지 좁은 책임만 갖는다. 후보 데이터 자체(심볼 인덱스, 파일 인덱스,
+      슬래시 명령 레지스트리) 는 외부 객체에서 받는다.
     - DIP: :class:`SymbolCompleter` 는 :class:`SymbolResolverProtocol`,
-      :class:`SlashRegistryProtocol` 추상에만 의존한다. 테스트는 작은 fake 객체를
-      주입해 readline 없이 콜백을 검증할 수 있다.
+      :class:`SlashRegistryProtocol` 추상에만 의존한다. 테스트는 작은 fake
+      객체를 주입해 readline 없이 콜백을 검증할 수 있다.
     - ISP: 외부에 강요하는 메서드가 ``all_records()`` / ``commands()`` 두 개로
-      쪼개져 있어 큰 인터페이스 한 덩어리에 엮이지 않는다.
+      쪼개져 있어 큰 인터페이스 한 덩어리에 엮이지 않는다. 본 컴플리터는
+      ``all_records()`` 결과를 자체적으로 :class:`SymbolRecord` /
+      :class:`FileRecord` 로 분리해 다룬다(이슈 #24).
     - 안전성: ``import readline`` 이 실패하는 환경(예: Windows 기본 파이썬,
       pyreadline3 미설치)에서도 :func:`setup_readline_completer` 는 조용히 리턴해
       REPL 본체가 동작 가능한 상태를 유지한다(graceful fallback).
 
-수용 기준 매핑(이슈 #20):
-    - ``@`` prefix 후보: :meth:`SymbolCompleter._complete_symbol`.
-    - ``/`` prefix 후보: :meth:`SymbolCompleter._complete_slash`.
-    - 매치 0건일 때 ``state=0`` 에 ``None`` 반환: :meth:`SymbolCompleter.__call__`.
-    - 후보 상한 20건: :data:`MAX_SYMBOL_CANDIDATES`.
-    - readline 미존재 환경에서 예외 없이 노옵: :func:`setup_readline_completer`.
+수용 기준 매핑(이슈 #24):
+    - ``@README`` 탭 → ``@README.md`` 후보 노출(확장자 생략 보정).
+    - ``@sicode/r`` 탭 → ``@sicode/repl.py`` 후보 노출(경로 segment prefix).
+    - 후보는 심볼 + 파일 합산 최대 :data:`MAX_CANDIDATES` 건, 알파벳 정렬.
 """
 
 from __future__ import annotations
 
 from typing import Callable, List, Optional, Protocol
 
-from sicode.symbols.indexer import SymbolRecord
+from sicode.symbols.indexer import FileRecord, IndexedRecord, SymbolRecord
 
 
-#: 한 번의 ``@`` prefix 자동완성에서 노출할 최대 후보 수.
-#: 이슈 #20 정책: 인덱스에 심볼이 더 많아도 20건만 반환한다.
+#: 한 번의 ``@`` prefix 자동완성에서 노출할 최대 후보 수(심볼 + 파일 합산).
+#: 이슈 #24 정책: 심볼·파일 후보를 각각 산출 후 합쳐 알파벳 정렬, 상한 20.
+MAX_CANDIDATES: int = 20
+
+#: 심볼 후보의 개별 상한(이슈 #20 호환). 합산 후 :data:`MAX_CANDIDATES` 로 다시
+#: 잘릴 수 있다.
 MAX_SYMBOL_CANDIDATES: int = 20
+
+#: 파일 후보의 개별 상한(이슈 #24). 합산 후 :data:`MAX_CANDIDATES` 로 다시
+#: 잘릴 수 있다.
+MAX_FILE_CANDIDATES: int = 20
 
 #: ``readline.set_completer_delims`` 에 설정할 구분자 문자열.
 #: 기본 delims 에는 ``@`` 가 포함돼 있어 ``@Symbol`` 입력 도중 Tab 을 누르면
@@ -49,7 +57,7 @@ COMPLETER_DELIMS: str = " \t\n"
 class SymbolResolverProtocol(Protocol):
     """후보 산출에 필요한 :class:`SymbolResolver` 의 최소 계약(ISP)."""
 
-    def all_records(self) -> List[SymbolRecord]:  # pragma: no cover - 프로토콜
+    def all_records(self) -> "List[IndexedRecord]":  # pragma: no cover - 프로토콜
         ...
 
 
@@ -72,7 +80,7 @@ class _NamedCommand(Protocol):
 
 
 class SymbolCompleter:
-    """``@심볼`` 과 ``/명령`` 자동완성을 제공하는 readline 콜백.
+    """``@심볼`` / ``@파일`` / ``/명령`` 자동완성을 제공하는 readline 콜백.
 
     한 인스턴스는 ``(resolver, registry)`` 쌍 한 묶음을 표현한다. ``state=0``
     일 때 ``text`` 의 prefix 분기에 따라 후보 리스트를 1회 계산해 캐시하고,
@@ -88,11 +96,11 @@ class SymbolCompleter:
         """완성기를 초기화한다.
 
         Args:
-            resolver: ``@`` 후보 산출에 사용할 심볼 리졸버. 본 객체는 ``all_records()``
-                만 호출되며, 캐시/invalidate 정책은 :class:`SymbolResolver` 본체가
-                책임진다.
-            registry: ``/`` 후보 산출에 사용할 슬래시 명령 레지스트리. ``None`` 이면
-                슬래시 자동완성은 후보 0건이 된다.
+            resolver: ``@`` 후보 산출에 사용할 심볼 리졸버. 본 객체는
+                ``all_records()`` 만 호출되며, 캐시/invalidate 정책은
+                :class:`SymbolResolver` 본체가 책임진다.
+            registry: ``/`` 후보 산출에 사용할 슬래시 명령 레지스트리. ``None``
+                이면 슬래시 자동완성은 후보 0건이 된다.
         """
         self._resolver: SymbolResolverProtocol = resolver
         self._registry: Optional[SlashRegistryProtocol] = registry
@@ -132,7 +140,7 @@ class SymbolCompleter:
     def _build_candidates(self, text: str) -> List[str]:
         """``text`` 의 prefix 에 따라 후보 리스트를 만든다.
 
-        - ``@...`` : 심볼 prefix 일치(대소문자 구분, 알파벳 오름차순, 최대 20).
+        - ``@...`` : 심볼 prefix 일치 + 파일 prefix 일치를 합산(이슈 #24).
         - ``/...`` : 슬래시 명령 prefix 일치(알파벳 오름차순).
         - 그 외   : 빈 리스트(자동완성 비활성).
         """
@@ -143,20 +151,47 @@ class SymbolCompleter:
         return []
 
     def _complete_symbol(self, prefix: str) -> List[str]:
-        """심볼 이름 prefix 일치 후보를 ``@Name`` 형태로 반환한다.
+        """``@`` 토큰 prefix 일치 후보를 ``@Name`` / ``@path/file`` 로 반환한다.
 
-        매칭 정책(이슈 #20):
-            - 대소문자 구분 prefix 일치.
-            - 같은 이름 중복 제거(파일이 달라도 이름이 같으면 후보 하나).
-            - 알파벳 오름차순 정렬.
-            - 최대 :data:`MAX_SYMBOL_CANDIDATES` 건.
+        매칭 정책(이슈 #24):
+            - 심볼 후보(:meth:`_complete_symbol_names`) 와 파일 후보
+              (:meth:`_complete_file_paths`) 를 각각 산출한다(SRP — 두 종류의
+              매칭 규칙을 별도 헬퍼로 격리).
+            - 두 결과를 합쳐 알파벳 오름차순으로 정렬하고 상위
+              :data:`MAX_CANDIDATES` 건을 반환한다.
+            - 같은 토큰을 두 종류가 모두 만들 가능성은 낮지만, 중복은
+              :class:`dict` 로 제거한다(파이썬 3.7+ 삽입 순서 보존).
 
         ``prefix`` 가 빈 문자열이면 ``@`` 만 입력된 상태이므로 인덱스 전체에서
-        앞 20건을 보여 준다(이미 정렬·중복 제거된 결과).
+        앞 :data:`MAX_CANDIDATES` 건을 보여 준다.
         """
         records = self._resolver.all_records()
+
+        symbol_candidates = self._complete_symbol_names(records, prefix)
+        file_candidates = self._complete_file_paths(records, prefix)
+
+        merged: "dict[str, None]" = {}
+        for name in symbol_candidates:
+            merged.setdefault(name, None)
+        for name in file_candidates:
+            merged.setdefault(name, None)
+
+        sorted_candidates = sorted(merged.keys())
+        return sorted_candidates[:MAX_CANDIDATES]
+
+    def _complete_symbol_names(
+        self, records: "List[IndexedRecord]", prefix: str
+    ) -> List[str]:
+        """심볼 이름 prefix 매칭(이슈 #20 호환).
+
+        - 대소문자 구분 prefix.
+        - 같은 이름 중복 제거(파일이 달라도 이름이 같으면 후보 하나).
+        - 알파벳 오름차순, 최대 :data:`MAX_SYMBOL_CANDIDATES` 건.
+        """
         seen: "dict[str, None]" = {}
         for record in records:
+            if not isinstance(record, SymbolRecord):
+                continue
             name = record.name
             if not name.startswith(prefix):
                 continue
@@ -166,6 +201,35 @@ class SymbolCompleter:
         names = sorted(seen.keys())
         limited = names[:MAX_SYMBOL_CANDIDATES]
         return [f"@{name}" for name in limited]
+
+    def _complete_file_paths(
+        self, records: "List[IndexedRecord]", prefix: str
+    ) -> List[str]:
+        """파일 경로/이름 prefix 매칭(이슈 #24).
+
+        매칭 규칙:
+            - ``rel_path`` 가 ``prefix`` 로 시작(전체 경로 prefix). 예:
+              ``sicode/r`` → ``sicode/repl.py``.
+            - 파일 이름 ``name`` 이 ``prefix`` 로 시작(루트 파일 / segment).
+              예: ``READ`` → ``README.md``.
+            - 파일은 같은 경로가 인덱스에 한 건만 있으므로 중복 제거는 ``dict``
+              keyed-on rel_path 로 처리.
+            - 알파벳 오름차순(``rel_path`` 기준), 최대
+              :data:`MAX_FILE_CANDIDATES` 건.
+
+        ``prefix`` 가 빈 문자열이면 모든 파일이 후보가 된다(상한 적용).
+        """
+        seen: "dict[str, None]" = {}
+        for record in records:
+            if not isinstance(record, FileRecord):
+                continue
+            rel_path = record.rel_path
+            name = record.name
+            if rel_path.startswith(prefix) or name.startswith(prefix):
+                seen.setdefault(rel_path, None)
+        paths = sorted(seen.keys())
+        limited = paths[:MAX_FILE_CANDIDATES]
+        return [f"@{path}" for path in limited]
 
     def _complete_slash(self, prefix: str) -> List[str]:
         """슬래시 명령 이름 prefix 일치 후보를 ``/name`` 형태로 반환한다.
@@ -233,6 +297,8 @@ _ImportHook = Callable[[], object]
 
 __all__ = [
     "COMPLETER_DELIMS",
+    "MAX_CANDIDATES",
+    "MAX_FILE_CANDIDATES",
     "MAX_SYMBOL_CANDIDATES",
     "SlashRegistryProtocol",
     "SymbolCompleter",

--- a/sicode/symbols/expand.py
+++ b/sicode/symbols/expand.py
@@ -1,25 +1,34 @@
-"""@토큰 → user message 본문 확장기(이슈 #17).
+"""@토큰 → user message 본문 확장기(이슈 #17, #24).
 
-사용자 입력에서 ``@[A-Za-z_][A-Za-z0-9_]*`` 패턴 토큰을 추출하고, 매칭된
-심볼 정의를 본문 끝에 코드 펜스 블록으로 append 한다.
+사용자 입력에서 ``@`` 로 시작하는 토큰을 추출하고, 매칭된 심볼 정의 또는
+파일 본문을 본문 끝에 코드 펜스 블록으로 append 한다.
 
 설계 메모:
     - SRP: 본 모듈은 "user message 변환" 한 가지 책임만 갖는다. 인덱싱은
       :mod:`sicode.symbols.indexer`, 검색은 :mod:`sicode.symbols.resolver`.
     - DIP: :class:`SymbolExpander` 는 :class:`SymbolResolver` 추상에만 의존한다.
-    - 출력 형식은 이슈 본문 명세를 따르며, 한 심볼은 최대
-      :data:`DEFAULT_MAX_SYMBOL_LINES` 라인까지 첨부한다(초과 시
-      ``... (truncated)`` 표기). 동일 심볼에 여러 매칭이 있으면 최대
-      :data:`DEFAULT_MAX_MATCHES` 건만 첨부한다.
+    - 이슈 #24 부터는 토큰 패턴이 두 가지를 모두 받는다:
+        1. 식별자 토큰: ``@ClassName`` / ``@function_name`` (기존 동작 유지).
+        2. 파일 토큰: ``@README.md``, ``@sicode/repl.py`` (점·슬래시 포함).
+      파일 매칭이 우선이며, 파일이 매칭되지 않은 식별자 토큰은 심볼 매칭으로
+      떨어진다(파일도 심볼도 매칭되지 않으면 안내 문구).
+    - 한 심볼은 :data:`DEFAULT_MAX_SYMBOL_LINES` 라인까지, 한 파일은
+      :data:`DEFAULT_MAX_FILE_LINES` 라인까지 첨부한다.
 """
 
 from __future__ import annotations
 
+import os
 import re
-from typing import List, Optional
+from pathlib import Path
+from typing import List, Optional, Tuple
 
+from sicode.symbols.indexer import (
+    DEFAULT_MAX_FILE_BYTES,
+    FileRecord,
+    SymbolRecord,
+)
 from sicode.symbols.resolver import SymbolResolver
-from sicode.symbols.indexer import SymbolRecord
 
 
 #: 한 심볼 토큰에 대해 첨부할 매칭 결과의 최대 개수.
@@ -28,15 +37,27 @@ DEFAULT_MAX_MATCHES: int = 3
 #: 한 심볼 정의 본문의 최대 라인 수.
 DEFAULT_MAX_SYMBOL_LINES: int = 150
 
-#: ``@토큰`` 추출용 정규식. 토큰은 식별자 규칙(맨 앞 영문/언더스코어).
-TOKEN_PATTERN: "re.Pattern[str]" = re.compile(r"@([A-Za-z_][A-Za-z0-9_]*)")
+#: 한 파일 본문의 최대 라인 수(이슈 #24).
+DEFAULT_MAX_FILE_LINES: int = 200
+
+#: ``@토큰`` 추출용 정규식.
+#:
+#: 이슈 #17 의 식별자 패턴(``@ClassName``)과 이슈 #24 의 파일 토큰
+#: (``@README.md``, ``@sicode/repl.py``) 을 함께 받는다. 시작 문자는 영문/언더
+#: 스코어/숫자 모두 허용(파일명이 숫자로 시작할 수도 있으므로). 본문에는 점·
+#: 슬래시·하이픈도 허용한다. 매칭이 인덱스에 없는 임의 문자열까지 잡지
+#: 않도록 끝은 알파벳/숫자/언더스코어로 마감되도록 정규식을 좁힌다.
+TOKEN_PATTERN: "re.Pattern[str]" = re.compile(
+    r"@([A-Za-z0-9_][A-Za-z0-9_./\-]*[A-Za-z0-9_]|[A-Za-z0-9_])"
+)
 
 
 class SymbolExpander:
-    """@토큰을 매칭된 심볼 코드로 확장하는 변환기.
+    """@토큰을 매칭된 심볼/파일 코드로 확장하는 변환기.
 
-    한 인스턴스는 (resolver, max_matches, max_symbol_lines) 한 묶음을 표현하며
-    :meth:`expand` 는 입력 문자열을 받아 변환된 새 문자열을 반환한다(원본은 변경 X).
+    한 인스턴스는 (resolver, max_matches, max_symbol_lines, max_file_lines,
+    file_root) 한 묶음을 표현하며 :meth:`expand` 는 입력 문자열을 받아 변환된
+    새 문자열을 반환한다(원본은 변경 X).
     """
 
     def __init__(
@@ -45,6 +66,9 @@ class SymbolExpander:
         *,
         max_matches: int = DEFAULT_MAX_MATCHES,
         max_symbol_lines: int = DEFAULT_MAX_SYMBOL_LINES,
+        max_file_lines: int = DEFAULT_MAX_FILE_LINES,
+        max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+        file_root: Optional[Path] = None,
     ) -> None:
         """확장기를 초기화한다.
 
@@ -52,6 +76,11 @@ class SymbolExpander:
             resolver: 토큰 → 레코드 검색을 위임할 :class:`SymbolResolver`.
             max_matches: 한 토큰당 본문에 포함할 매칭 수의 상한.
             max_symbol_lines: 한 심볼 정의 본문의 라인 상한.
+            max_file_lines: 한 파일 본문의 라인 상한(이슈 #24, 기본 200).
+            max_file_bytes: 본문을 읽을 파일 크기 상한. 초과 파일은 메타데이터만
+                첨부한다(이슈 #24, 기본 1 MB).
+            file_root: 파일 본문을 읽을 루트. ``None`` 이면 :func:`Path.cwd`.
+                ``rel_path`` 를 본 루트에 결합해 본문을 읽는다.
 
         Raises:
             ValueError: 한도 값이 1 미만일 때.
@@ -60,9 +89,16 @@ class SymbolExpander:
             raise ValueError("max_matches must be >= 1")
         if max_symbol_lines < 1:
             raise ValueError("max_symbol_lines must be >= 1")
+        if max_file_lines < 1:
+            raise ValueError("max_file_lines must be >= 1")
+        if max_file_bytes < 1:
+            raise ValueError("max_file_bytes must be >= 1")
         self._resolver: SymbolResolver = resolver
         self._max_matches: int = max_matches
         self._max_symbol_lines: int = max_symbol_lines
+        self._max_file_lines: int = max_file_lines
+        self._max_file_bytes: int = max_file_bytes
+        self._file_root: Path = (file_root or Path.cwd()).resolve()
 
     def expand(self, user_input: str) -> str:
         """``@토큰`` 을 추출해 매칭된 코드 블록을 본문 끝에 append 한다.
@@ -95,17 +131,107 @@ class SymbolExpander:
     # ------------------------------------------------------------------ helpers
 
     def _render_token(self, token: str) -> str:
-        """단일 토큰에 대해 매칭 결과 또는 안내 문구를 렌더링한다."""
-        records = self._resolver.find(token)
-        if not records:
-            return f"(note: @{token} — no definition found in project)"
+        """단일 토큰에 대해 매칭 결과 또는 안내 문구를 렌더링한다.
 
-        attached = records[: self._max_matches]
-        blocks = [
-            _render_record_block(token, record, self._max_symbol_lines)
-            for record in attached
+        매칭 우선순위(이슈 #24): 파일 → 심볼 → 안내. 같은 토큰이 파일과 심볼
+        양쪽에서 매칭되더라도 파일 본문이 더 직접적인 컨텍스트라는 정책을
+        취해 파일을 먼저 첨부한다.
+        """
+        files = self._resolver.find_files(token)
+        if files:
+            attached = files[: self._max_matches]
+            blocks = [self._render_file_block(token, record) for record in attached]
+            return "---\n" + "\n\n".join(blocks)
+
+        symbols = self._resolver.find(token)
+        if symbols:
+            attached_symbols = symbols[: self._max_matches]
+            symbol_blocks = [
+                _render_symbol_block(token, record, self._max_symbol_lines)
+                for record in attached_symbols
+            ]
+            return "---\n" + "\n\n".join(symbol_blocks)
+
+        return f"(note: @{token} — no definition found in project)"
+
+    def _render_file_block(self, token: str, record: FileRecord) -> str:
+        """단일 :class:`FileRecord` 를 코드 펜스 블록으로 렌더링한다.
+
+        본문 첨부 정책(이슈 #24):
+            - ``is_oversize=True`` 이거나 ``is_binary=True`` 이면 메타데이터만
+              안내 라인으로 첨부한다.
+            - 그 외에는 디스크에서 본문을 읽어 :data:`DEFAULT_MAX_FILE_LINES`
+              까지 첨부하고, 초과 시 ``[truncated]`` 라인을 붙인다.
+            - 디스크 읽기 실패는 메타데이터 폴백.
+        """
+        if record.is_binary:
+            return (
+                f"Referenced file: `@{token}` ({record.rel_path}, "
+                f"{record.size_bytes} bytes, binary — content omitted)"
+            )
+        if record.is_oversize:
+            return (
+                f"Referenced file: `@{token}` ({record.rel_path}, "
+                f"{record.size_bytes} bytes, exceeds 1 MB — content omitted)"
+            )
+
+        body, truncated = self._read_file_body(record)
+        if body is None:
+            return (
+                f"Referenced file: `@{token}` ({record.rel_path}, "
+                f"{record.size_bytes} bytes — content unreadable)"
+            )
+
+        fence_lines = [
+            f"Referenced file: `@{token}` ({record.rel_path})",
+            "```",
+            body.rstrip("\n"),
         ]
-        return "---\n" + "\n\n".join(blocks)
+        if truncated:
+            fence_lines.append("[truncated]")
+        fence_lines.append("```")
+        return "\n".join(fence_lines)
+
+    def _read_file_body(self, record: FileRecord) -> "Tuple[Optional[str], bool]":
+        """파일 본문을 최대 ``max_file_lines`` 까지 읽는다.
+
+        Returns:
+            ``(본문, truncated)`` 튜플. 권한/디코드 실패 시 ``(None, False)``.
+        """
+        # ``rel_path`` 는 인덱서가 만든 POSIX 경로다. ``file_root`` 와 결합해
+        # OS 네이티브 경로로 풀어 디스크에서 다시 읽는다.
+        target = self._file_root.joinpath(*record.rel_path.split("/"))
+        # ``file_root`` 바깥으로의 탈출(예: 인덱서가 다른 root 였던 경우) 차단.
+        try:
+            resolved = target.resolve()
+        except OSError:
+            return None, False
+        try:
+            resolved.relative_to(self._file_root)
+        except ValueError:
+            return None, False
+
+        try:
+            with resolved.open("rb") as fh:
+                data = fh.read(self._max_file_bytes + 1)
+        except OSError:
+            return None, False
+
+        # 인덱싱 시점 이후 파일이 커져 max_file_bytes 를 넘긴 경우 메타데이터
+        # 폴백(상위 호출자가 처리한다).
+        if len(data) > self._max_file_bytes:
+            return None, False
+
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            return None, False
+
+        lines = text.splitlines()
+        if len(lines) <= self._max_file_lines:
+            return text, False
+        clipped = "\n".join(lines[: self._max_file_lines])
+        return clipped, True
 
 
 def _extract_tokens(text: str) -> List[str]:
@@ -118,7 +244,7 @@ def _extract_tokens(text: str) -> List[str]:
     return list(seen.keys())
 
 
-def _render_record_block(
+def _render_symbol_block(
     token: str, record: "SymbolRecord", max_lines: int
 ) -> str:
     """단일 :class:`SymbolRecord` 를 본문에 첨부할 텍스트 블록으로 렌더한다.
@@ -158,6 +284,7 @@ def expand_user_input(
     *,
     max_matches: int = DEFAULT_MAX_MATCHES,
     max_symbol_lines: int = DEFAULT_MAX_SYMBOL_LINES,
+    max_file_lines: int = DEFAULT_MAX_FILE_LINES,
 ) -> str:
     """모듈 수준 편의 함수: 일회성으로 :class:`SymbolExpander` 를 만들어 적용.
 
@@ -168,11 +295,13 @@ def expand_user_input(
         resolver or SymbolResolver(),
         max_matches=max_matches,
         max_symbol_lines=max_symbol_lines,
+        max_file_lines=max_file_lines,
     )
     return expander.expand(user_input)
 
 
 __all__ = [
+    "DEFAULT_MAX_FILE_LINES",
     "DEFAULT_MAX_MATCHES",
     "DEFAULT_MAX_SYMBOL_LINES",
     "SymbolExpander",

--- a/sicode/symbols/indexer.py
+++ b/sicode/symbols/indexer.py
@@ -1,18 +1,28 @@
-"""Python 심볼 인덱서(이슈 #17).
+"""Python 심볼 / 파일 인덱서(이슈 #17, #24).
 
-작업 디렉토리 트리를 한 번 walk 하면서 ``*.py`` 파일을 ``ast`` 로 파싱하고
-``ClassDef`` / ``FunctionDef`` / ``AsyncFunctionDef`` 노드의 위치 정보와 원본
-소스 슬라이스를 :class:`SymbolRecord` 로 수집한다.
+본 모듈은 두 종류의 인덱서를 제공한다.
+
+- :class:`SymbolIndexer` (이슈 #17): 작업 디렉토리 트리를 walk 하며 ``*.py``
+  파일을 ``ast`` 로 파싱해 ``ClassDef`` / ``FunctionDef`` /
+  ``AsyncFunctionDef`` 노드를 :class:`SymbolRecord` 로 수집한다.
+- :class:`FileIndexer` (이슈 #24): 같은 트리를 walk 하며 모든 비-바이너리·
+  비-시크릿·비-과대 파일을 :class:`FileRecord` 로 수집한다. ``@README``,
+  ``@sicode/repl.py`` 같은 파일 토큰 자동완성/expand 의 데이터 소스다.
+- :class:`CompositeIndexer` (이슈 #24): 두 인덱서를 묶어
+  :class:`IndexerProtocol` 한 번의 ``build()`` 로 통합 레코드를 돌려준다.
 
 설계 메모:
-    - SRP: 본 모듈은 "디렉토리 → SymbolRecord 리스트" 변환만 담당한다. 캐시,
-      검색, 사용자 입력 가공은 다른 모듈이 책임진다.
-    - DIP: :class:`SymbolIndexer` 는 ``Path`` 와 디스크 IO 만 알고, 무시 패턴
-      판정은 외부에서 주입받은 함수에 위임한다(테스트에서 교체 가능). 기본값은
-      :func:`sicode.init.scanner._matches_any` 와 ``DEFAULT_IGNORE_PATTERNS``
-      를 재사용해 "한 곳에만 보안 패턴이 정의되어 있다" 는 단일 출처 원칙을 유지.
-    - 외부 의존성 없이 표준 라이브러리(``ast``, ``pathlib``, ``os``, ``fnmatch``)
-      만 사용한다.
+    - SRP: 각 인덱서는 "디렉토리 → 자기 종류의 레코드 리스트" 변환만 담당한다.
+      캐시·검색·첨부는 :mod:`resolver` / :mod:`expand` 가 책임진다.
+    - DIP: 각 인덱서는 ``Path`` 와 디스크 IO 만 알고, 무시 패턴 판정은 외부
+      에서 주입받은 함수에 위임한다(테스트에서 교체 가능). 기본값은
+      :data:`sicode.init.scanner.DEFAULT_IGNORE_PATTERNS` 한 곳에서만 정의된
+      보안 패턴을 재사용한다.
+    - ISP: :class:`IndexerProtocol` 은 ``build() -> Iterable[record]`` 한
+      메서드만 요구한다. 콘크리트 인덱서는 자기 record 타입을 돌려주기만 하면
+      교체 가능하다.
+    - 외부 의존성 없이 표준 라이브러리(``ast``, ``pathlib``, ``os``,
+      ``fnmatch``) 만 사용한다.
 """
 
 from __future__ import annotations
@@ -22,7 +32,7 @@ import fnmatch
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Iterable, List, Optional, Tuple
+from typing import Callable, Iterable, List, Optional, Protocol, Sequence, Tuple, Union
 
 from sicode.init.scanner import DEFAULT_IGNORE_PATTERNS
 
@@ -256,10 +266,233 @@ def iter_python_files(
     yield from _walk(root)
 
 
+# ---------------------------------------------------------------------------
+# File indexer (issue #24)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FileRecord:
+    """인덱싱된 단일 파일.
+
+    ``@파일명`` 자동완성/expand 의 데이터 소스(이슈 #24).
+
+    Attributes:
+        name: 파일의 마지막 segment(``README.md``, ``repl.py`` 등).
+        rel_path: 인덱싱 루트 기준 POSIX 상대 경로.
+        kind: 항상 ``"file"``. :class:`SymbolRecord` 와의 식별 차단용.
+        start_line: 항상 ``1`` (이슈 본문 정책). expand 시 본문은 1번 라인부터
+            시작한다.
+        snippet: 본문 미리보기. 인덱싱 시점에는 메모리 부담을 피하기 위해
+            기본적으로 빈 문자열이다. 본문 첨부는 :class:`SymbolExpander` 가
+            expand 시점에 디스크에서 다시 읽는다(저용량 인덱스 유지).
+        size_bytes: 파일 크기. ``stat`` 실패 시 ``0``.
+        is_binary: NULL 바이트 휴리스틱으로 바이너리로 판정된 경우 ``True``.
+        is_oversize: ``max_file_bytes`` 초과 시 ``True``.
+    """
+
+    name: str
+    rel_path: str
+    kind: str = "file"
+    start_line: int = 1
+    snippet: str = ""
+    size_bytes: int = 0
+    is_binary: bool = False
+    is_oversize: bool = False
+
+
+#: :class:`SymbolIndexer` / :class:`FileIndexer` 가 돌려주는 통합 레코드 타입.
+IndexedRecord = Union[SymbolRecord, FileRecord]
+
+
+def _is_probably_binary(path: Path, sample_size: int = 1024) -> bool:
+    """파일 앞부분의 NULL 바이트 존재 여부로 바이너리 추정(이슈 #24).
+
+    :func:`sicode.init.scanner._is_probably_binary` 와 동일한 휴리스틱이지만,
+    의존 방향을 단순하게 유지하기 위해 패턴만 재구현했다(상수
+    ``DEFAULT_IGNORE_PATTERNS`` 만 import). 권한 문제 등으로 읽기 실패 시
+    안전하게 바이너리로 간주해 본문 수집을 건너뛴다.
+    """
+    try:
+        with path.open("rb") as fh:
+            chunk = fh.read(sample_size)
+    except OSError:
+        return True
+    if not chunk:
+        return False
+    return b"\x00" in chunk
+
+
+class FileIndexer:
+    """디렉토리 트리에서 일반 파일을 :class:`FileRecord` 로 수집하는 인덱서.
+
+    수집 정책(이슈 #24):
+        - 이름 기반 무시 패턴(:data:`DEFAULT_IGNORE_PATTERNS`) 에 매칭되는 파일·
+          디렉토리는 제외한다(시크릿/`.git/`/`__pycache__/` 등).
+        - 심볼릭 링크는 따라가지 않는다(루프 / 외부 노출 방지).
+        - 크기/바이너리 판정 결과는 :class:`FileRecord` 의 플래그로 기록되지만
+          레코드 자체는 인덱스에 포함된다(자동완성 후보로 노출하기 위함).
+          본문 첨부는 expander 가 같은 플래그를 다시 검사해 결정한다.
+        - ``snippet`` 은 인덱싱 시점에 본문을 읽지 않는다(저용량 인덱스).
+    """
+
+    def __init__(
+        self,
+        root: Optional[Path] = None,
+        *,
+        ignore_matcher: Optional[IgnoreMatcher] = None,
+        max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+    ) -> None:
+        """인덱서를 초기화한다.
+
+        Args:
+            root: 인덱싱 루트. ``None`` 이면 :func:`Path.cwd`.
+            ignore_matcher: 디렉토리/파일 이름을 받고 무시 여부를 반환하는 함수.
+                ``None`` 이면 :data:`DEFAULT_IGNORE_PATTERNS` 기반 기본 매처.
+            max_file_bytes: ``is_oversize`` 플래그 임계값. 초과해도 인덱스에는
+                포함되지만 본문은 첨부되지 않는다.
+        """
+        self._root: Path = (root or Path.cwd()).resolve()
+        self._ignore: IgnoreMatcher = ignore_matcher or _default_ignore_matcher()
+        self._max_file_bytes: int = max_file_bytes
+
+    @property
+    def root(self) -> Path:
+        """인덱싱 루트 경로(절대)."""
+        return self._root
+
+    def build(self) -> List[FileRecord]:
+        """루트를 한 번 walk 해 :class:`FileRecord` 리스트를 만든다."""
+        records: List[FileRecord] = []
+        self._walk(self._root, records)
+        return records
+
+    # ------------------------------------------------------------------ helpers
+
+    def _walk(self, directory: Path, sink: List[FileRecord]) -> None:
+        try:
+            children = sorted(directory.iterdir(), key=lambda p: p.name)
+        except OSError:
+            return
+
+        for child in children:
+            name = child.name
+            if self._ignore(name):
+                continue
+            if child.is_symlink():
+                continue
+            if child.is_dir():
+                self._walk(child, sink)
+                continue
+            if child.is_file():
+                self._index_file(child, sink)
+
+    def _index_file(self, path: Path, sink: List[FileRecord]) -> None:
+        size = _safe_size(path)
+        is_oversize = size > self._max_file_bytes
+        # 바이너리 판정은 oversize 가 아닐 때만 시도(거대한 파일을 굳이 1KB 읽을
+        # 필요는 없지만, 안전하게 oversize 면 메타만 남기고 바이너리 판정 생략).
+        is_binary = False if is_oversize else _is_probably_binary(path)
+        rel = _relpath(path, self._root)
+        sink.append(
+            FileRecord(
+                name=path.name,
+                rel_path=rel,
+                kind="file",
+                start_line=1,
+                snippet="",
+                size_bytes=size,
+                is_binary=is_binary,
+                is_oversize=is_oversize,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Composite indexer (issue #24)
+# ---------------------------------------------------------------------------
+
+
+class _IndexerLike(Protocol):
+    """:class:`CompositeIndexer` 가 받아들이는 최소 인덱서 계약(ISP).
+
+    ``build()`` 한 메서드만 요구한다. :class:`SymbolIndexer`,
+    :class:`FileIndexer`, 또는 임의의 stub 인덱서가 모두 본 프로토콜을
+    만족한다.
+    """
+
+    def build(self) -> "List[IndexedRecord]":  # pragma: no cover - 프로토콜 정의
+        ...
+
+
+class CompositeIndexer:
+    """여러 :class:`_IndexerLike` 결과를 하나의 ``build()`` 로 통합한다.
+
+    SRP/DIP: 본 클래스는 "여러 인덱서의 결과 합치기" 한 가지 책임만 갖고,
+    각 인덱서는 자기 종류의 레코드 수집만 담당한다.
+    :class:`SymbolResolver` 는 :class:`_IndexerLike` 추상에만 의존하므로
+    :class:`SymbolIndexer` 단독, :class:`CompositeIndexer` 로 묶인 두 인덱서,
+    또는 테스트용 stub 등 어떤 것이든 주입할 수 있다.
+    """
+
+    def __init__(
+        self,
+        indexers: Sequence[_IndexerLike],
+    ) -> None:
+        """여러 인덱서를 묶는다.
+
+        Args:
+            indexers: ``build()`` 메서드를 가진 객체의 시퀀스. 호출 순서대로
+                결과가 이어 붙는다.
+        """
+        self._indexers: Tuple[_IndexerLike, ...] = tuple(indexers)
+
+    def build(self) -> List[IndexedRecord]:
+        """모든 인덱서를 호출해 결과를 이어 붙인다.
+
+        Returns:
+            각 인덱서가 돌려준 레코드를 호출 순서대로 이어 붙인 리스트.
+        """
+        merged: List[IndexedRecord] = []
+        for indexer in self._indexers:
+            merged.extend(indexer.build())
+        return merged
+
+
+def make_default_composite_indexer(
+    root: Optional[Path] = None,
+    *,
+    ignore_matcher: Optional[IgnoreMatcher] = None,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+) -> CompositeIndexer:
+    """기본 :class:`SymbolIndexer` + :class:`FileIndexer` 묶음을 만든다.
+
+    :class:`SymbolResolver` 가 ``indexer=None`` 으로 초기화될 때 lazy 로 호출
+    하는 팩토리. 같은 (root, ignore_matcher, max_file_bytes) 설정을 두 인덱서
+    가 공유하도록 보장한다.
+    """
+    symbol_indexer = SymbolIndexer(
+        root,
+        ignore_matcher=ignore_matcher,
+        max_file_bytes=max_file_bytes,
+    )
+    file_indexer = FileIndexer(
+        root,
+        ignore_matcher=ignore_matcher,
+        max_file_bytes=max_file_bytes,
+    )
+    return CompositeIndexer([symbol_indexer, file_indexer])
+
+
 __all__ = [
     "DEFAULT_MAX_FILE_BYTES",
+    "CompositeIndexer",
+    "FileIndexer",
+    "FileRecord",
     "IgnoreMatcher",
+    "IndexedRecord",
     "SymbolIndexer",
     "SymbolRecord",
     "iter_python_files",
+    "make_default_composite_indexer",
 ]

--- a/sicode/symbols/resolver.py
+++ b/sicode/symbols/resolver.py
@@ -1,16 +1,20 @@
-"""심볼 토큰 해석기(이슈 #17).
+"""심볼 / 파일 토큰 해석기(이슈 #17, #24).
 
-:class:`SymbolResolver` 는 :class:`SymbolIndexer` 가 만든 :class:`SymbolRecord`
-목록을 in-memory 캐시로 보관하고, 토큰을 정확 일치 → 대소문자 무시 부분
-일치 순서로 검색한다.
+:class:`SymbolResolver` 는 :class:`IndexerProtocol` 결과(:class:`SymbolRecord`
+또는 :class:`FileRecord`) 를 in-memory 캐시로 보관하고, 토큰을 두 종류
+모두에 대해 검색한다.
 
 설계 메모:
     - SRP: 본 클래스는 "토큰 → 매칭 결과" 변환과 캐시 무효화만 책임진다.
       디스크 IO 와 사용자 입력 가공은 이웃 모듈이 담당.
-    - DIP: :class:`SymbolIndexer` 추상에 의존하므로 테스트에서 다른 인덱서를
-      주입할 수 있다(예: 미리 만들어 둔 in-memory 인덱서).
-    - 상태 정책: 첫 :meth:`find` 호출 시 lazy 인덱싱을 1회 수행한다.
-      :meth:`invalidate` 가 호출되면 다음 :meth:`find` 시 다시 인덱싱한다.
+    - DIP: 인덱서는 ``build() -> List[record]`` 한 메서드만 요구하는 작은
+      프로토콜에 의존하므로, :class:`SymbolIndexer` / :class:`FileIndexer` /
+      :class:`CompositeIndexer` 또는 임의의 stub 어느 것이든 주입 가능.
+    - ISP: 외부에는 검색 메서드(``find`` / ``find_files``)와 조회 메서드
+      (``all_records`` / ``all_symbols`` / ``all_files``)를 분리해 노출한다.
+      자동완성기는 ``all_*`` 만, expander 는 ``find*`` 만 사용한다.
+    - 상태 정책: 첫 검색 호출 시 lazy 인덱싱을 1회 수행한다.
+      :meth:`invalidate` 가 호출되면 다음 검색 시 다시 인덱싱한다.
       ``/clear`` 슬래시 명령은 :meth:`invalidate` 만 호출한다.
 """
 
@@ -18,45 +22,78 @@ from __future__ import annotations
 
 from typing import List, Optional, Protocol
 
-from sicode.symbols.indexer import SymbolIndexer, SymbolRecord
+from sicode.symbols.indexer import (
+    FileRecord,
+    IndexedRecord,
+    SymbolRecord,
+    make_default_composite_indexer,
+)
 
 
 class SymbolIndexerProtocol(Protocol):
-    """인덱서가 지켜야 할 작은 계약(테스트에서 mock 교체 용)."""
+    """인덱서가 지켜야 할 작은 계약(테스트에서 mock 교체 용).
 
-    def build(self) -> List[SymbolRecord]:  # pragma: no cover - 프로토콜 정의
+    이름은 역사적 호환을 위해 ``Symbol-`` 접두사를 유지하지만, 본 프로토콜은
+    :class:`SymbolRecord` / :class:`FileRecord` 어느 쪽이든 ``build()`` 가
+    돌려주는 모든 레코드 타입을 받는다. 이름 변경은 외부 API 깨짐을 막기 위해
+    하지 않는다.
+    """
+
+    def build(self) -> "List[IndexedRecord]":  # pragma: no cover - 프로토콜 정의
         ...
 
 
 class SymbolResolver:
-    """심볼 인덱스를 lazy 로 만들고 토큰 검색을 제공하는 캐시.
+    """심볼/파일 인덱스를 lazy 로 만들고 토큰 검색을 제공하는 캐시.
 
     인스턴스 단위로 캐시를 보관한다. 같은 REPL 세션이 같은 resolver 를 공유
-    하면 인덱싱 비용이 한 번만 발생한다.
+    하면 인덱싱 비용이 한 번만 발생한다(이슈 #17). 이슈 #24 부터는 같은 캐시
+    안에 :class:`SymbolRecord` 와 :class:`FileRecord` 가 함께 보관되며, 두
+    종류 모두 ``/clear`` 한 번으로 무효화된다.
     """
 
     def __init__(self, indexer: Optional[SymbolIndexerProtocol] = None) -> None:
         """리졸버를 초기화한다.
 
         Args:
-            indexer: 사용할 인덱서. ``None`` 이면 기본 :class:`SymbolIndexer`
-                (``Path.cwd`` 루트, 기본 ignore/크기) 가 lazy 로 만들어진다.
+            indexer: 사용할 인덱서. ``None`` 이면 :func:`make_default_composite_indexer`
+                로 ``Path.cwd`` 기반 (SymbolIndexer + FileIndexer) 묶음이 lazy
+                로 만들어진다(이슈 #24).
         """
         self._indexer: Optional[SymbolIndexerProtocol] = indexer
-        self._cache: Optional[List[SymbolRecord]] = None
+        self._cache: Optional[List[IndexedRecord]] = None
 
     def invalidate(self) -> None:
-        """캐시를 비운다. 다음 :meth:`find` 호출이 다시 인덱싱한다."""
+        """캐시를 비운다. 다음 검색 호출이 다시 인덱싱한다.
+
+        이슈 #24: 단일 캐시 안에 심볼·파일 레코드가 함께 들어 있으므로
+        ``/clear`` 한 번으로 두 종류 모두 무효화된다.
+        """
         self._cache = None
 
-    def all_records(self) -> List[SymbolRecord]:
-        """현재 인덱스의 모든 레코드를 반환한다(없으면 lazy 인덱싱)."""
+    def all_records(self) -> List[IndexedRecord]:
+        """현재 인덱스의 모든 레코드를 반환한다(없으면 lazy 인덱싱).
+
+        ``SymbolCompleter`` 가 후보 산출에 사용하는 진입점.
+        """
         return list(self._records())
+
+    def all_symbols(self) -> List[SymbolRecord]:
+        """심볼 종류의 레코드만 필터링해 반환한다(이슈 #24).
+
+        기존 호출자(``SymbolCompleter._complete_symbol`` 같은 일부 경로) 가
+        심볼만 보고 싶을 때 사용한다.
+        """
+        return [r for r in self._records() if isinstance(r, SymbolRecord)]
+
+    def all_files(self) -> List[FileRecord]:
+        """파일 종류의 레코드만 필터링해 반환한다(이슈 #24)."""
+        return [r for r in self._records() if isinstance(r, FileRecord)]
 
     def find(self, token: str) -> List[SymbolRecord]:
         """토큰과 매칭되는 :class:`SymbolRecord` 리스트를 반환한다.
 
-        매칭 정책(이슈 #17):
+        매칭 정책(이슈 #17, 호환 유지):
             1. 대소문자 구분 정확 일치가 한 건이라도 있으면 그 결과만 반환.
             2. 정확 일치가 없으면 대소문자 무시 부분 일치(``substring``) 결과를 반환.
             3. 어떤 매칭도 없으면 빈 리스트.
@@ -65,12 +102,12 @@ class SymbolResolver:
             token: ``@`` 가 제거된 식별자(예: ``Conversation``).
 
         Returns:
-            매칭된 레코드 리스트. 입력 토큰이 빈 문자열이면 빈 리스트.
+            매칭된 심볼 레코드 리스트. 입력 토큰이 빈 문자열이면 빈 리스트.
         """
         if not token:
             return []
 
-        records = self._records()
+        records = self.all_symbols()
         exact: List[SymbolRecord] = [r for r in records if r.name == token]
         if exact:
             return exact
@@ -81,12 +118,70 @@ class SymbolResolver:
         ]
         return partial
 
+    def find_files(self, token: str) -> List[FileRecord]:
+        """토큰과 매칭되는 :class:`FileRecord` 리스트를 반환한다(이슈 #24).
+
+        매칭 정책:
+            1. 대소문자 구분 정확 일치(상대 경로 ``rel_path`` 또는 파일 이름
+               ``name``) 가 있으면 그 결과만 반환.
+            2. 확장자 생략 보정: ``token`` 에 ``"."`` 이 없으면
+               ``f"{token}.*"`` 패턴으로 ``name`` 을 ``fnmatch`` 매칭(``@README``
+               → ``README.md``).
+            3. 위 둘 다 없으면 대소문자 무시 segment prefix 매칭. ``rel_path``
+               를 ``"/"`` 로 분할해 마지막 segment 가 prefix 매치이면 후보.
+               전체 ``rel_path`` 가 prefix 매치인 경우도 포함(``sicode/r`` →
+               ``sicode/repl.py``).
+
+        Args:
+            token: ``@`` 가 제거된 파일 토큰(``README.md``, ``sicode/repl.py`` 등).
+
+        Returns:
+            매칭된 파일 레코드 리스트. 빈 토큰이면 빈 리스트.
+        """
+        if not token:
+            return []
+
+        records = self.all_files()
+
+        # 1. 대소문자 구분 정확 일치(rel_path 또는 name).
+        exact: List[FileRecord] = [
+            r for r in records if r.rel_path == token or r.name == token
+        ]
+        if exact:
+            return exact
+
+        # 2. 확장자 생략 보정: ``@README`` → ``README.md`` 류.
+        if "." not in token and "/" not in token:
+            import fnmatch as _fn
+
+            ext_match: List[FileRecord] = [
+                r for r in records if _fn.fnmatch(r.name, f"{token}.*")
+            ]
+            if ext_match:
+                return ext_match
+
+        # 3. 대소문자 무시 segment / 경로 prefix 매칭.
+        lowered = token.lower()
+        partial: List[FileRecord] = []
+        for record in records:
+            rel_lower = record.rel_path.lower()
+            name_lower = record.name.lower()
+            # 전체 경로 prefix.
+            if rel_lower.startswith(lowered):
+                partial.append(record)
+                continue
+            # 마지막 segment prefix.
+            if name_lower.startswith(lowered):
+                partial.append(record)
+                continue
+        return partial
+
     # ------------------------------------------------------------------ helpers
 
-    def _records(self) -> List[SymbolRecord]:
+    def _records(self) -> List[IndexedRecord]:
         """캐시가 있으면 재사용, 없으면 인덱서를 호출해 채운다."""
         if self._cache is None:
-            indexer = self._indexer or SymbolIndexer()
+            indexer = self._indexer or make_default_composite_indexer()
             self._indexer = indexer
             self._cache = list(indexer.build())
         return self._cache

--- a/tests/symbols/test_file_completer.py
+++ b/tests/symbols/test_file_completer.py
@@ -1,0 +1,150 @@
+"""SymbolCompleter 의 파일 후보 합산(이슈 #24) 단위 테스트."""
+
+from __future__ import annotations
+
+from typing import List
+
+from sicode.symbols.completer import (
+    MAX_CANDIDATES,
+    MAX_FILE_CANDIDATES,
+    MAX_SYMBOL_CANDIDATES,
+    SymbolCompleter,
+)
+from sicode.symbols.indexer import FileRecord, IndexedRecord, SymbolRecord
+
+
+def _file(rel_path: str) -> FileRecord:
+    name = rel_path.rsplit("/", 1)[-1]
+    return FileRecord(
+        name=name,
+        rel_path=rel_path,
+        kind="file",
+        start_line=1,
+        snippet="",
+        size_bytes=0,
+        is_binary=False,
+        is_oversize=False,
+    )
+
+
+def _symbol(name: str) -> SymbolRecord:
+    return SymbolRecord(
+        name=name,
+        kind="class",
+        rel_path="dummy.py",
+        start_line=1,
+        end_line=1,
+        source=f"class {name}:\n    pass\n",
+    )
+
+
+class FakeResolver:
+    def __init__(self, records: List[IndexedRecord]) -> None:
+        self._records = records
+
+    def all_records(self) -> List[IndexedRecord]:
+        return list(self._records)
+
+
+class TestFileCompletion:
+    def test_root_file_prefix_returns_at_path(self) -> None:
+        # 이슈 #24 수용 기준: ``@README`` 탭 → ``@README.md``
+        resolver = FakeResolver([_file("README.md"), _file("docs/extra.md")])
+        completer = SymbolCompleter(resolver)
+        assert completer("@README", 0) == "@README.md"
+        assert completer("@README", 1) is None
+
+    def test_segment_prefix_in_subdirectory(self) -> None:
+        # ``@sicode/r`` → ``@sicode/repl.py``
+        resolver = FakeResolver(
+            [_file("sicode/repl.py"), _file("sicode/main.py")]
+        )
+        completer = SymbolCompleter(resolver)
+        assert completer("@sicode/r", 0) == "@sicode/repl.py"
+        assert completer("@sicode/r", 1) is None
+
+    def test_no_file_match_returns_none(self) -> None:
+        resolver = FakeResolver([_file("README.md")])
+        completer = SymbolCompleter(resolver)
+        assert completer("@unknown_xyz", 0) is None
+
+
+class TestFileAndSymbolMerge:
+    def test_results_are_alphabetically_sorted_after_merge(self) -> None:
+        resolver = FakeResolver(
+            [
+                _symbol("Beta"),
+                _file("alpha.txt"),
+                _file("zeta.md"),
+            ]
+        )
+        completer = SymbolCompleter(resolver)
+        # 빈 prefix → 모든 후보. ``@`` 기호 정렬로 알파벳 순.
+        results: List[str] = []
+        idx = 0
+        while True:
+            value = completer("@", idx)
+            if value is None:
+                break
+            results.append(value)
+            idx += 1
+        # ``@Beta`` 는 대문자라 ASCII 순으로 ``@a-`` 보다 앞.
+        assert results == sorted(results)
+        assert "@Beta" in results
+        assert "@alpha.txt" in results
+        assert "@zeta.md" in results
+
+    def test_total_results_capped_at_max_candidates(self) -> None:
+        # 심볼 25 + 파일 25 → 합산 후 상한 :data:`MAX_CANDIDATES`.
+        records: List[IndexedRecord] = [
+            _symbol(f"Sym{i:02d}") for i in range(25)
+        ]
+        records.extend(_file(f"file{i:02d}.txt") for i in range(25))
+        resolver = FakeResolver(records)
+        completer = SymbolCompleter(resolver)
+
+        results: List[str] = []
+        idx = 0
+        while True:
+            value = completer("@", idx)
+            if value is None:
+                break
+            results.append(value)
+            idx += 1
+        assert len(results) == MAX_CANDIDATES
+
+    def test_caps_respected_for_each_kind_individually(self) -> None:
+        # 파일만 있을 때 :data:`MAX_FILE_CANDIDATES` 까지만 노출되어야 한다.
+        records: List[IndexedRecord] = [
+            _file(f"file{i:03d}.txt") for i in range(50)
+        ]
+        resolver = FakeResolver(records)
+        completer = SymbolCompleter(resolver)
+
+        results: List[str] = []
+        idx = 0
+        while True:
+            value = completer("@file", idx)
+            if value is None:
+                break
+            results.append(value)
+            idx += 1
+        # 파일 후보 상한은 MAX_FILE_CANDIDATES, 합산 상한은 MAX_CANDIDATES.
+        assert len(results) == min(MAX_FILE_CANDIDATES, MAX_CANDIDATES)
+
+
+class TestFileAndSymbolDoNotInterfereByDefault:
+    def test_symbol_only_completion_unchanged(self) -> None:
+        resolver = FakeResolver([_symbol("ConvergenceTool"), _symbol("Other")])
+        completer = SymbolCompleter(resolver)
+        assert completer("@Conv", 0) == "@ConvergenceTool"
+        assert completer("@Conv", 1) is None
+
+    def test_file_only_completion_works_without_symbols(self) -> None:
+        resolver = FakeResolver([_file("README.md")])
+        completer = SymbolCompleter(resolver)
+        assert completer("@README", 0) == "@README.md"
+
+    def test_max_candidate_constants_are_consistent(self) -> None:
+        # 합산 상한이 개별 상한 합보다 같거나 작다(설계 정책).
+        assert MAX_CANDIDATES <= MAX_SYMBOL_CANDIDATES + MAX_FILE_CANDIDATES

--- a/tests/symbols/test_file_expand.py
+++ b/tests/symbols/test_file_expand.py
@@ -1,0 +1,229 @@
+"""SymbolExpander 의 파일 첨부(이슈 #24) 단위 테스트."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from sicode.symbols.expand import (
+    DEFAULT_MAX_FILE_LINES,
+    SymbolExpander,
+)
+from sicode.symbols.indexer import FileRecord, IndexedRecord, SymbolRecord
+from sicode.symbols.resolver import SymbolResolver
+
+
+class _MixedIndexer:
+    def __init__(self, records: List[IndexedRecord]) -> None:
+        self._records = list(records)
+
+    def build(self) -> List[IndexedRecord]:
+        return list(self._records)
+
+
+def _file(
+    rel_path: str,
+    *,
+    size_bytes: int = 0,
+    is_binary: bool = False,
+    is_oversize: bool = False,
+) -> FileRecord:
+    return FileRecord(
+        name=rel_path.rsplit("/", 1)[-1],
+        rel_path=rel_path,
+        kind="file",
+        start_line=1,
+        snippet="",
+        size_bytes=size_bytes,
+        is_binary=is_binary,
+        is_oversize=is_oversize,
+    )
+
+
+def _symbol(name: str) -> SymbolRecord:
+    return SymbolRecord(
+        name=name,
+        kind="class",
+        rel_path="m.py",
+        start_line=1,
+        end_line=2,
+        source=f"class {name}:\n    pass\n",
+    )
+
+
+class TestFileBodyAttachment:
+    def test_attaches_file_body_within_limit(self, tmp_path: Path) -> None:
+        target = tmp_path / "main.py"
+        target.write_text("print('hello')\n", encoding="utf-8")
+
+        resolver = SymbolResolver(_MixedIndexer([_file("main.py")]))
+        expander = SymbolExpander(resolver, file_root=tmp_path)
+        result = expander.expand("@main.py 설명")
+
+        assert "Referenced file: `@main.py`" in result
+        assert "(main.py)" in result
+        assert "print('hello')" in result
+        assert "[truncated]" not in result
+
+    def test_truncates_file_body_at_two_hundred_lines(
+        self, tmp_path: Path
+    ) -> None:
+        # 250 라인 파일 → 200 라인까지 첨부되고 [truncated] 안내.
+        lines = [f"line_{i}" for i in range(250)]
+        target = tmp_path / "big.txt"
+        target.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        resolver = SymbolResolver(_MixedIndexer([_file("big.txt")]))
+        expander = SymbolExpander(resolver, file_root=tmp_path)
+        result = expander.expand("@big.txt")
+
+        # 200번째 라인까지는 포함되어야 한다.
+        assert "line_199" in result
+        # 201번째 라인부터는 잘려서 빠진다.
+        assert "line_200" not in result
+        assert "[truncated]" in result
+
+    def test_default_max_file_lines_is_two_hundred(self) -> None:
+        assert DEFAULT_MAX_FILE_LINES == 200
+
+    def test_short_file_does_not_get_truncated_label(
+        self, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "tiny.txt"
+        target.write_text("hi\n", encoding="utf-8")
+
+        resolver = SymbolResolver(_MixedIndexer([_file("tiny.txt")]))
+        expander = SymbolExpander(resolver, file_root=tmp_path)
+        result = expander.expand("@tiny.txt")
+        assert "[truncated]" not in result
+
+    def test_extension_omission_attaches_full_file(
+        self, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "README.md"
+        target.write_text("# hello\n", encoding="utf-8")
+
+        resolver = SymbolResolver(_MixedIndexer([_file("README.md")]))
+        expander = SymbolExpander(resolver, file_root=tmp_path)
+        result = expander.expand("@README 설명")
+        assert "Referenced file: `@README`" in result
+        assert "# hello" in result
+
+
+class TestOversizedAndBinaryFiles:
+    def test_oversized_attaches_metadata_only(self, tmp_path: Path) -> None:
+        # 인덱서가 oversize 로 마킹한 파일은 본문 대신 메타데이터만.
+        record = _file("huge.bin", size_bytes=2 * 1024 * 1024, is_oversize=True)
+        resolver = SymbolResolver(_MixedIndexer([record]))
+        expander = SymbolExpander(resolver, file_root=tmp_path)
+        result = expander.expand("@huge.bin")
+
+        assert "Referenced file: `@huge.bin`" in result
+        assert "exceeds 1 MB" in result
+        # 본문 펜스(```)가 첨부되지 않는다.
+        assert "```" not in result
+
+    def test_binary_attaches_metadata_only(self, tmp_path: Path) -> None:
+        record = _file("blob.bin", size_bytes=128, is_binary=True)
+        resolver = SymbolResolver(_MixedIndexer([record]))
+        expander = SymbolExpander(resolver, file_root=tmp_path)
+        result = expander.expand("@blob.bin")
+
+        assert "binary — content omitted" in result
+        assert "```" not in result
+
+
+class TestSecretFilesAreNotAttached:
+    def test_secret_pattern_not_indexed_so_not_attached(
+        self, tmp_path: Path
+    ) -> None:
+        # FileIndexer 가 ``DEFAULT_IGNORE_PATTERNS`` 로 ``.env`` 를 차단하므로
+        # 어떤 형태로 토큰이 들어오든 본문이 첨부되면 안 된다.
+        from sicode.symbols.indexer import FileIndexer
+
+        (tmp_path / ".env").write_text("SECRET=1\n", encoding="utf-8")
+        (tmp_path / "main.py").write_text("x = 1\n", encoding="utf-8")
+
+        composite_records: List[IndexedRecord] = list(
+            FileIndexer(tmp_path).build()
+        )
+        resolver = SymbolResolver(_MixedIndexer(composite_records))
+        expander = SymbolExpander(resolver, file_root=tmp_path)
+        # 시크릿은 인덱스에 없으므로 ``find_files`` 결과가 비어 있다.
+        assert resolver.find_files(".env") == []
+
+        # 토큰 패턴은 ``@`` 다음에 영문/숫자/언더스코어로 시작해야 하므로
+        # ``@.env`` 는 토큰으로 잡히지 않아 입력이 그대로 보존된다.
+        # 어느 쪽이든 본문 ``SECRET=1`` 이 새지 않는 것이 핵심.
+        result = expander.expand("@.env")
+        assert "SECRET=1" not in result
+
+
+class TestNoMatchPolicy:
+    def test_unknown_token_keeps_input_and_appends_note(
+        self, tmp_path: Path
+    ) -> None:
+        resolver = SymbolResolver(_MixedIndexer([]))
+        expander = SymbolExpander(resolver, file_root=tmp_path)
+        result = expander.expand("@unknown_xyz 무엇?")
+
+        # 원본 입력이 유지된다.
+        assert result.startswith("@unknown_xyz 무엇?")
+        # 안내 문구가 붙는다(예외 없이).
+        assert "no definition found" in result
+
+    def test_file_match_takes_priority_over_symbol_match(
+        self, tmp_path: Path
+    ) -> None:
+        # 같은 토큰 ``Foo`` 가 파일 ``Foo`` (확장자 없는) 와 심볼 ``Foo`` 양쪽
+        # 인덱스에 있을 때, 파일이 우선 첨부된다.
+        target = tmp_path / "Foo"
+        target.write_text("file body\n", encoding="utf-8")
+        resolver = SymbolResolver(
+            _MixedIndexer([_symbol("Foo"), _file("Foo")])
+        )
+        expander = SymbolExpander(resolver, file_root=tmp_path)
+        result = expander.expand("@Foo")
+
+        assert "Referenced file: `@Foo`" in result
+        assert "file body" in result
+        # 심볼 헤더 라인이 등장하지 않아야 한다(파일 우선 정책).
+        assert "Referenced symbol: `@Foo`" not in result
+
+
+class TestPathTraversalSafety:
+    def test_does_not_read_outside_file_root(self, tmp_path: Path) -> None:
+        outer = tmp_path / "outside"
+        outer.mkdir()
+        (outer / "secret.txt").write_text("LEAK\n", encoding="utf-8")
+
+        inner = tmp_path / "inner"
+        inner.mkdir()
+
+        # 인덱서가 부정확한 ``rel_path`` 를 만들었다고 가정해도, expander 는
+        # ``file_root`` 바깥의 본문을 읽으면 안 된다.
+        record = _file("../outside/secret.txt")
+        resolver = SymbolResolver(_MixedIndexer([record]))
+        expander = SymbolExpander(resolver, file_root=inner)
+        result = expander.expand("@../outside/secret.txt")
+
+        # 본문 LEAK 이 새지 않아야 한다.
+        assert "LEAK" not in result
+
+
+class TestExpanderConfigValidation:
+    def test_max_file_lines_must_be_positive(self) -> None:
+        with pytest.raises(ValueError):
+            SymbolExpander(
+                SymbolResolver(_MixedIndexer([])),
+                max_file_lines=0,
+            )
+
+    def test_max_file_bytes_must_be_positive(self) -> None:
+        with pytest.raises(ValueError):
+            SymbolExpander(
+                SymbolResolver(_MixedIndexer([])),
+                max_file_bytes=0,
+            )

--- a/tests/symbols/test_file_indexer.py
+++ b/tests/symbols/test_file_indexer.py
@@ -1,0 +1,195 @@
+"""FileIndexer / CompositeIndexer 단위 테스트(이슈 #24)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sicode.symbols.indexer import (
+    CompositeIndexer,
+    DEFAULT_MAX_FILE_BYTES,
+    FileIndexer,
+    FileRecord,
+    SymbolIndexer,
+    SymbolRecord,
+    make_default_composite_indexer,
+)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_bytes(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+
+
+class TestFileIndexerBasic:
+    def test_collects_top_level_text_files(self, tmp_path: Path) -> None:
+        _write(tmp_path / "README.md", "# hello\n")
+        _write(tmp_path / "main.py", "x = 1\n")
+        records = FileIndexer(tmp_path).build()
+        names = sorted(r.name for r in records)
+        assert names == ["README.md", "main.py"]
+        for record in records:
+            assert isinstance(record, FileRecord)
+            assert record.kind == "file"
+            assert record.start_line == 1
+            # 인덱싱 시점에는 본문을 읽지 않는다(저용량 인덱스).
+            assert record.snippet == ""
+
+    def test_records_relative_path_in_posix_style(self, tmp_path: Path) -> None:
+        _write(tmp_path / "pkg" / "sub" / "m.py", "x = 1\n")
+        records = FileIndexer(tmp_path).build()
+        rels = sorted(r.rel_path for r in records)
+        assert rels == ["pkg/sub/m.py"]
+
+    def test_collects_non_python_files(self, tmp_path: Path) -> None:
+        _write(tmp_path / "notes.txt", "memo\n")
+        _write(tmp_path / "data.json", "{}\n")
+        records = FileIndexer(tmp_path).build()
+        names = sorted(r.name for r in records)
+        assert names == ["data.json", "notes.txt"]
+
+    def test_marks_oversized_files(self, tmp_path: Path) -> None:
+        big = tmp_path / "big.txt"
+        big.write_text("x" * 1024, encoding="utf-8")
+        records = FileIndexer(tmp_path, max_file_bytes=100).build()
+        # 인덱스에는 포함되지만 메타데이터로만.
+        assert len(records) == 1
+        assert records[0].is_oversize is True
+        assert records[0].size_bytes == 1024
+
+    def test_marks_binary_files(self, tmp_path: Path) -> None:
+        # NULL 바이트가 들어간 바이너리 파일.
+        _write_bytes(tmp_path / "blob.bin", b"abc\x00def")
+        _write(tmp_path / "ok.txt", "ascii\n")
+        records = sorted(FileIndexer(tmp_path).build(), key=lambda r: r.name)
+        names = [r.name for r in records]
+        assert names == ["blob.bin", "ok.txt"]
+        binary = next(r for r in records if r.name == "blob.bin")
+        text = next(r for r in records if r.name == "ok.txt")
+        assert binary.is_binary is True
+        assert text.is_binary is False
+
+    def test_default_max_file_bytes_is_one_megabyte(self) -> None:
+        assert DEFAULT_MAX_FILE_BYTES == 1024 * 1024
+
+
+class TestFileIndexerIgnorePatterns:
+    def test_default_ignores_dot_env(self, tmp_path: Path) -> None:
+        _write(tmp_path / ".env", "SECRET=1\n")
+        _write(tmp_path / "ok.py", "x = 1\n")
+        records = FileIndexer(tmp_path).build()
+        names = [r.name for r in records]
+        assert ".env" not in names
+        assert "ok.py" in names
+
+    def test_default_ignores_pem(self, tmp_path: Path) -> None:
+        _write(tmp_path / "key.pem", "-----BEGIN-----\n")
+        _write(tmp_path / "ok.py", "x = 1\n")
+        records = FileIndexer(tmp_path).build()
+        names = [r.name for r in records]
+        assert "key.pem" not in names
+        assert "ok.py" in names
+
+    def test_default_ignores_git_directory(self, tmp_path: Path) -> None:
+        _write(tmp_path / ".git" / "HEAD", "ref: refs/heads/main\n")
+        _write(tmp_path / "ok.py", "x = 1\n")
+        records = FileIndexer(tmp_path).build()
+        names = [r.name for r in records]
+        assert "HEAD" not in names
+        assert "ok.py" in names
+
+    def test_default_ignores_pycache(self, tmp_path: Path) -> None:
+        _write(tmp_path / "__pycache__" / "cached.pyc", "")
+        _write(tmp_path / "ok.py", "x = 1\n")
+        records = FileIndexer(tmp_path).build()
+        names = [r.name for r in records]
+        assert "cached.pyc" not in names
+        assert "ok.py" in names
+
+    def test_default_ignores_credentials(self, tmp_path: Path) -> None:
+        _write(tmp_path / "credentials.json", "{}\n")
+        _write(tmp_path / "ok.py", "x = 1\n")
+        records = FileIndexer(tmp_path).build()
+        names = [r.name for r in records]
+        assert "credentials.json" not in names
+        assert "ok.py" in names
+
+    def test_custom_ignore_matcher_overrides_default(self, tmp_path: Path) -> None:
+        _write(tmp_path / "skipme.txt", "x")
+        _write(tmp_path / "keep.txt", "x")
+
+        def _ignore(name: str) -> bool:
+            return name == "skipme.txt"
+
+        records = FileIndexer(tmp_path, ignore_matcher=_ignore).build()
+        names = sorted(r.name for r in records)
+        assert names == ["keep.txt"]
+
+
+class TestFileIndexerSymlinkSafety:
+    def test_skips_symlinks_when_walking(self, tmp_path: Path) -> None:
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("leak\n", encoding="utf-8")
+        link = tmp_path / "inside_link"
+        try:
+            link.symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError):  # pragma: no cover
+            pytest.skip("symlink unsupported on this platform")
+
+        # 인덱싱 루트는 ``tmp_path`` 다. ``inside_link`` 는 symlink 이므로 walk 가
+        # 따라가지 않아 ``secret.txt`` 가 결과에 포함되지 않아야 한다.
+        # (단, ``outside`` 자체는 ``tmp_path`` 의 자식이므로 walk 됨 — 그 사실이
+        # 본 테스트 설계의 약점인데, 여기선 ``outside`` 도 같은 트리이므로
+        # ``secret.txt`` 가 포함되는 게 정상이다. 이 케이스에서는 link 자체가
+        # 결과에 포함되지 않는 것만 검증하면 충분.)
+        records = FileIndexer(tmp_path).build()
+        rels = [r.rel_path for r in records]
+        # 링크 디렉토리 자체는 결과 트리에 등장하지 않는다.
+        assert not any(rel.startswith("inside_link/") for rel in rels)
+
+
+class TestCompositeIndexer:
+    def test_merges_two_indexers_in_order(self, tmp_path: Path) -> None:
+        _write(tmp_path / "m.py", "class Foo:\n    pass\n")
+        _write(tmp_path / "README.md", "# hi\n")
+
+        composite = CompositeIndexer(
+            [SymbolIndexer(tmp_path), FileIndexer(tmp_path)]
+        )
+        records = composite.build()
+
+        symbol_names = [
+            r.name for r in records if isinstance(r, SymbolRecord)
+        ]
+        file_names = sorted(
+            r.name for r in records if isinstance(r, FileRecord)
+        )
+        assert symbol_names == ["Foo"]
+        assert file_names == ["README.md", "m.py"]
+
+    def test_make_default_composite_uses_both_indexers(
+        self, tmp_path: Path
+    ) -> None:
+        _write(tmp_path / "m.py", "class Foo:\n    pass\n")
+        _write(tmp_path / "README.md", "# hi\n")
+
+        composite = make_default_composite_indexer(tmp_path)
+        records = composite.build()
+
+        types = {
+            "symbol": sum(1 for r in records if isinstance(r, SymbolRecord)),
+            "file": sum(1 for r in records if isinstance(r, FileRecord)),
+        }
+        assert types["symbol"] >= 1
+        assert types["file"] >= 2  # README.md + m.py
+
+    def test_empty_indexer_list_returns_empty(self) -> None:
+        composite = CompositeIndexer([])
+        assert composite.build() == []

--- a/tests/symbols/test_file_integration.py
+++ b/tests/symbols/test_file_integration.py
@@ -1,0 +1,163 @@
+"""파일 토큰(@파일명) 통합 흐름 테스트(이슈 #24).
+
+본 모듈은 :class:`FileIndexer` + :class:`SymbolResolver` + :class:`SymbolExpander`
+가 실제 디스크에서 함께 동작할 때 이슈 #24 의 수용 기준을 만족하는지 확인한다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sicode.commands import ClearCommand, register_default_commands
+from sicode.commands.base import ReplContext
+from sicode.commands.clear import SUCCESS_MESSAGE as CLEAR_SUCCESS
+from sicode.modes.ollama import OllamaMode
+from sicode.modes.ollama_chat import OllamaChatClient
+from sicode.symbols import (
+    CompositeIndexer,
+    FileIndexer,
+    SymbolExpander,
+    SymbolIndexer,
+    SymbolResolver,
+)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+class TestEndToEndFileExpansion:
+    def test_readme_token_attaches_file_body(self, tmp_path: Path) -> None:
+        _write(tmp_path / "README.md", "# Title\n\nbody\n")
+
+        composite = CompositeIndexer(
+            [SymbolIndexer(tmp_path), FileIndexer(tmp_path)]
+        )
+        resolver = SymbolResolver(composite)
+        expander = SymbolExpander(resolver, file_root=tmp_path)
+
+        result = expander.expand("@README 설명해줘")
+        assert "# Title" in result
+        assert "body" in result
+        assert "Referenced file:" in result
+
+    def test_subpath_token_attaches_file_body(self, tmp_path: Path) -> None:
+        _write(tmp_path / "sicode" / "repl.py", "def repl():\n    return\n")
+
+        composite = CompositeIndexer(
+            [SymbolIndexer(tmp_path), FileIndexer(tmp_path)]
+        )
+        resolver = SymbolResolver(composite)
+        expander = SymbolExpander(resolver, file_root=tmp_path)
+
+        result = expander.expand("@sicode/repl.py")
+        assert "def repl():" in result
+        assert "Referenced file: `@sicode/repl.py`" in result
+
+    def test_secret_file_is_not_attached_or_indexed(
+        self, tmp_path: Path
+    ) -> None:
+        _write(tmp_path / ".env", "SECRET=should-not-leak\n")
+
+        composite = CompositeIndexer(
+            [SymbolIndexer(tmp_path), FileIndexer(tmp_path)]
+        )
+        resolver = SymbolResolver(composite)
+        expander = SymbolExpander(resolver, file_root=tmp_path)
+
+        # 자동완성 후보에 노출되지 않는다.
+        files = resolver.all_files()
+        assert all(f.name != ".env" for f in files)
+        # 직접 검색해도 인덱스에 없다.
+        assert resolver.find_files(".env") == []
+
+        # expand 시에도 본문이 첨부되지 않는다(어떤 토큰 형태든).
+        result = expander.expand("@.env")
+        assert "should-not-leak" not in result
+
+    def test_unknown_token_passes_through_with_note(
+        self, tmp_path: Path
+    ) -> None:
+        composite = CompositeIndexer(
+            [SymbolIndexer(tmp_path), FileIndexer(tmp_path)]
+        )
+        resolver = SymbolResolver(composite)
+        expander = SymbolExpander(resolver, file_root=tmp_path)
+
+        result = expander.expand("@unknown_xyz 무엇?")
+        assert result.startswith("@unknown_xyz 무엇?")
+        assert "no definition found" in result
+
+    def test_oversized_file_attaches_metadata_only(
+        self, tmp_path: Path
+    ) -> None:
+        big = tmp_path / "huge.txt"
+        # 1 MB + 약간 — FileIndexer 가 oversize 마킹.
+        big.write_text("x" * (1024 * 1024 + 100), encoding="utf-8")
+
+        composite = CompositeIndexer(
+            [SymbolIndexer(tmp_path), FileIndexer(tmp_path)]
+        )
+        resolver = SymbolResolver(composite)
+        expander = SymbolExpander(resolver, file_root=tmp_path)
+
+        result = expander.expand("@huge.txt")
+        assert "Referenced file: `@huge.txt`" in result
+        assert "exceeds 1 MB" in result
+        # 본문 1 MB 가 그대로 첨부되면 안 된다.
+        assert "x" * 1024 not in result
+
+
+class TestClearInvalidatesFileIndex:
+    def test_clear_clears_file_records_on_resolver(
+        self, tmp_path: Path
+    ) -> None:
+        # 1) 초기 인덱싱: README.md 만 존재.
+        readme = tmp_path / "README.md"
+        readme.write_text("# v1\n", encoding="utf-8")
+
+        composite = CompositeIndexer(
+            [SymbolIndexer(tmp_path), FileIndexer(tmp_path)]
+        )
+        resolver = SymbolResolver(composite)
+        # lazy 인덱싱 트리거.
+        first_files = sorted(f.name for f in resolver.all_files())
+        assert first_files == ["README.md"]
+
+        # 2) 디스크에 새 파일 추가 후 invalidate 전에는 보이지 않는다.
+        (tmp_path / "NEW.md").write_text("# new\n", encoding="utf-8")
+        cached_files = sorted(f.name for f in resolver.all_files())
+        assert "NEW.md" not in cached_files
+
+        # 3) /clear 가 호출하는 invalidate() 후 다시 조회하면 NEW.md 가 인덱스에
+        #    잡힌다(file index 도 함께 무효화됨).
+        resolver.invalidate()
+        rebuilt = sorted(f.name for f in resolver.all_files())
+        assert "NEW.md" in rebuilt
+
+    def test_clear_command_invalidates_resolver_with_files(
+        self, tmp_path: Path
+    ) -> None:
+        register_default_commands()
+
+        composite = CompositeIndexer(
+            [SymbolIndexer(tmp_path), FileIndexer(tmp_path)]
+        )
+        resolver = SymbolResolver(composite)
+        resolver.all_records()  # lazy 캐시 채움
+
+        mode = OllamaMode(
+            client=OllamaChatClient(),
+            symbol_resolver=resolver,
+        )
+        result = ClearCommand().execute(ReplContext(mode=mode))
+        assert result.output == CLEAR_SUCCESS
+        # invalidate 후 캐시는 비어 있어야 한다(다음 조회 시 재인덱싱).
+        # 외부 동작 확인: ``_cache`` 가 None 이라는 내부 상태 대신, 다음
+        # ``all_files()`` 호출이 디스크를 다시 본다는 사실로 검증.
+        # 새 파일을 추가해도 invalidate 가 작동했는지 확인한다.
+        (tmp_path / "afterclear.md").write_text("after\n", encoding="utf-8")
+        assert any(
+            f.name == "afterclear.md" for f in resolver.all_files()
+        )

--- a/tests/symbols/test_file_resolver.py
+++ b/tests/symbols/test_file_resolver.py
@@ -1,0 +1,159 @@
+"""SymbolResolver 의 파일 매칭(이슈 #24) 단위 테스트.
+
+기존 :mod:`tests.symbols.test_resolver` 는 심볼 매칭 동작에 집중한다. 본 모듈은
+이슈 #24 에서 추가된 ``find_files`` / ``all_files`` / 통합 캐시 무효화 동작을
+검증한다.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from sicode.symbols.indexer import FileRecord, IndexedRecord, SymbolRecord
+from sicode.symbols.resolver import SymbolResolver
+
+
+class _MixedIndexer:
+    """심볼/파일 레코드를 함께 돌려주는 in-memory 인덱서."""
+
+    def __init__(self, records: List[IndexedRecord]) -> None:
+        self._records = list(records)
+        self.build_calls: int = 0
+
+    def build(self) -> List[IndexedRecord]:
+        self.build_calls += 1
+        return list(self._records)
+
+
+def _file(rel_path: str, *, name: str = "", **flags: object) -> FileRecord:
+    return FileRecord(
+        name=name or rel_path.rsplit("/", 1)[-1],
+        rel_path=rel_path,
+        kind="file",
+        start_line=1,
+        snippet="",
+        size_bytes=int(flags.get("size_bytes", 0) or 0),
+        is_binary=bool(flags.get("is_binary", False)),
+        is_oversize=bool(flags.get("is_oversize", False)),
+    )
+
+
+def _symbol(name: str, *, rel_path: str = "m.py") -> SymbolRecord:
+    return SymbolRecord(
+        name=name,
+        kind="class",
+        rel_path=rel_path,
+        start_line=1,
+        end_line=2,
+        source=f"class {name}:\n    pass\n",
+    )
+
+
+class TestFindFilesExactMatch:
+    def test_exact_rel_path_match(self) -> None:
+        resolver = SymbolResolver(
+            _MixedIndexer([_file("sicode/repl.py"), _file("sicode/main.py")])
+        )
+        result = [r.rel_path for r in resolver.find_files("sicode/repl.py")]
+        assert result == ["sicode/repl.py"]
+
+    def test_exact_name_match(self) -> None:
+        resolver = SymbolResolver(
+            _MixedIndexer([_file("README.md"), _file("docs/README.md")])
+        )
+        result = sorted(r.rel_path for r in resolver.find_files("README.md"))
+        assert result == ["README.md", "docs/README.md"]
+
+    def test_extension_omission_returns_completion(self) -> None:
+        # ``@README`` 입력 → ``README.md`` 매칭.
+        resolver = SymbolResolver(_MixedIndexer([_file("README.md")]))
+        result = [r.rel_path for r in resolver.find_files("README")]
+        assert result == ["README.md"]
+
+    def test_no_match_returns_empty(self) -> None:
+        resolver = SymbolResolver(_MixedIndexer([_file("README.md")]))
+        assert resolver.find_files("does_not_exist") == []
+
+    def test_empty_token_returns_empty(self) -> None:
+        resolver = SymbolResolver(_MixedIndexer([_file("README.md")]))
+        assert resolver.find_files("") == []
+
+
+class TestFindFilesPrefix:
+    def test_segment_prefix_in_path(self) -> None:
+        # ``@sicode/r`` → ``sicode/repl.py``
+        resolver = SymbolResolver(
+            _MixedIndexer(
+                [_file("sicode/repl.py"), _file("sicode/main.py")]
+            )
+        )
+        result = sorted(r.rel_path for r in resolver.find_files("sicode/r"))
+        assert result == ["sicode/repl.py"]
+
+    def test_name_prefix_in_root_files(self) -> None:
+        resolver = SymbolResolver(
+            _MixedIndexer([_file("README.md"), _file("ROADMAP.md")])
+        )
+        result = sorted(r.rel_path for r in resolver.find_files("RO"))
+        assert result == ["ROADMAP.md"]
+
+    def test_case_insensitive_prefix(self) -> None:
+        resolver = SymbolResolver(_MixedIndexer([_file("README.md")]))
+        result = [r.rel_path for r in resolver.find_files("readme.m")]
+        # 정확 매치 / 확장자 보정 모두 실패 → 대소문자 무시 prefix.
+        assert result == ["README.md"]
+
+
+class TestAllRecordsAndCaching:
+    def test_all_records_includes_files_and_symbols(self) -> None:
+        records: List[IndexedRecord] = [
+            _symbol("Foo"),
+            _file("README.md"),
+        ]
+        resolver = SymbolResolver(_MixedIndexer(records))
+        result = resolver.all_records()
+        assert len(result) == 2
+        assert any(isinstance(r, SymbolRecord) for r in result)
+        assert any(isinstance(r, FileRecord) for r in result)
+
+    def test_all_files_filters_to_file_records(self) -> None:
+        records: List[IndexedRecord] = [
+            _symbol("Foo"),
+            _file("README.md"),
+            _file("main.py"),
+        ]
+        resolver = SymbolResolver(_MixedIndexer(records))
+        files = resolver.all_files()
+        assert sorted(f.name for f in files) == ["README.md", "main.py"]
+
+    def test_all_symbols_filters_to_symbol_records(self) -> None:
+        records: List[IndexedRecord] = [
+            _symbol("Foo"),
+            _file("README.md"),
+        ]
+        resolver = SymbolResolver(_MixedIndexer(records))
+        symbols = resolver.all_symbols()
+        assert [s.name for s in symbols] == ["Foo"]
+
+    def test_invalidate_clears_both_indexes(self) -> None:
+        indexer = _MixedIndexer([_symbol("Foo"), _file("README.md")])
+        resolver = SymbolResolver(indexer)
+        resolver.find("Foo")
+        resolver.find_files("README")
+        assert indexer.build_calls == 1
+
+        resolver.invalidate()
+        resolver.find("Foo")
+        # 무효화 후 build 가 다시 1회 호출.
+        assert indexer.build_calls == 2
+        # 이후 find_files 는 같은 캐시를 공유.
+        resolver.find_files("README")
+        assert indexer.build_calls == 2
+
+    def test_find_does_not_match_file_records(self) -> None:
+        # ``find`` 는 심볼 결과만 반환해야 한다(이슈 #24 호환 정책).
+        resolver = SymbolResolver(
+            _MixedIndexer([_file("Foo.py", name="Foo.py")])
+        )
+        # ``Foo.py`` 라는 파일이 있어도 심볼 ``Foo`` 매칭은 없으므로 빈 결과.
+        assert resolver.find("Foo") == []


### PR DESCRIPTION
Closes #24

## 요약
`@README`, `@sicode/repl.py` 같은 파일 토큰을 자동완성·expand 양쪽에서 지원합니다.
- `FileIndexer` 신규 인덱서가 작업 디렉토리를 walk 하며 `DEFAULT_IGNORE_PATTERNS`(시크릿/`.git/`/`__pycache__/`/바이너리/1 MB 초과)를 그대로 적용해 `FileRecord`를 수집.
- `CompositeIndexer`가 `SymbolIndexer` + `FileIndexer`를 묶어 `SymbolResolver` 단일 캐시로 통합.
- `SymbolCompleter`는 심볼/파일 후보를 알파벳 정렬해 합산 최대 20건 노출(확장자 생략, 경로 segment prefix).
- `SymbolExpander`는 파일 매칭 우선 → 본문 200줄까지 첨부, 200줄 초과 시 `[truncated]`, 1 MB 초과/바이너리는 메타데이터만, `file_root` 바깥 경로는 path-traversal 차단.
- `/clear`(`SymbolResolver.invalidate()`)가 단일 캐시이므로 심볼·파일 인덱스를 함께 무효화.

## 핵심 설계 결정
- **인덱서 분리(SRP)**: `SymbolIndexer`(AST 기반)와 `FileIndexer`(디렉토리 walk)를 별도 클래스로 두고 `_IndexerLike` 프로토콜로 추상화. `CompositeIndexer`가 이들을 결합해 `SymbolResolver`에 단일 `build()` 인터페이스를 제공.
- **resolver 메서드 분리(ISP)**: `find()`(심볼만)·`find_files()`(파일만)·`all_records()`/`all_symbols()`/`all_files()` 로 분리해 자동완성기는 후보 산출만, expander는 검색만 사용.
- **무시 패턴 단일 출처**: `sicode/init/scanner.DEFAULT_IGNORE_PATTERNS` 그대로 재사용 — 시크릿(`.env`, `*.pem`, `id_rsa*`, `credentials*` 등)이 인덱싱·expand 어느 단계에서도 새지 않음.
- **저용량 인덱스**: `FileRecord.snippet`은 인덱싱 시점 빈 문자열, expand 시점에만 디스크에서 본문 읽음(메모리 부담 없음).
- **파일 우선 정책**: 같은 토큰이 파일·심볼 둘 다 매칭되면 파일이 더 직접적 컨텍스트라는 정책상 파일 본문이 첨부됨.

## Test plan
- [x] `python -m pytest -q` → 467 passed (기존 367 + 신규 100건)
- [x] `@README` → `@README.md`, `@sicode/r` → `@sicode/repl.py` 자동완성 검증
- [x] 200줄 초과 파일 expand 시 `[truncated]` 첨부 검증
- [x] 1 MB 초과 / 바이너리 파일은 메타데이터만 첨부 검증
- [x] 시크릿(`DEFAULT_IGNORE_PATTERNS` 매칭) 인덱싱·expand 차단 검증
- [x] `/clear` 후 file index 재빌드 검증 (`invalidate()`가 단일 캐시 비움)
- [x] 알 수 없는 토큰은 입력 보존 + 안내 문구
- [x] `..` 같은 path traversal 시도는 file_root 바깥 본문을 읽지 않음
- [x] 기존 `@SymbolName` 동작 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)